### PR TITLE
GITHUB FIX - about not desc in template

### DIFF
--- a/.github/ISSUE_TEMPLATE/other_task.md
+++ b/.github/ISSUE_TEMPLATE/other_task.md
@@ -1,6 +1,6 @@
 ---
 name: "Other Task / POC / Documentation"
-description: "Template for uncategorized tasks, POCs, documentation, and miscellaneous issues."
+about: "Template for uncategorized tasks, POCs, documentation, and miscellaneous issues."
 title: "[Other] <short description>"
 labels: ["other", "task"]
 assignees: []


### PR DESCRIPTION
This pull request makes a minor update to the `.github/ISSUE_TEMPLATE/other_task.md` issue template. The change replaces the `description` field with the `about` field to better align with GitHub's template configuration.