### PR TITLE
GITHUB - HUB issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/hub_issue.md
+++ b/.github/ISSUE_TEMPLATE/hub_issue.md
@@ -1,0 +1,40 @@
+---
+name: "Hub Issue"
+about: "Template for hub issues that serve as a central point for tracking multiple sub-issues."
+title: "[Hub] <short description>"
+labels: ["hub", "epic"]
+assignees: []
+---
+
+## Description
+
+<!-- Provide a high-level description of the hub issue and its purpose. -->
+
+## Sub-Issues
+
+<!-- List all related sub-issues here. Use checkboxes for tracking progress. -->
+
+- [ ] #<issue_number> - <brief description>
+- [ ] #<issue_number> - <brief description>
+- [ ] #<issue_number> - <brief description>
+
+## Context
+
+<!-- Provide any relevant context, links, or background information. -->
+
+## Expected Outcome
+
+<!-- What is the overall goal or deliverable for this hub? -->
+
+## Progress Tracking
+
+<!-- Track the overall progress of the hub. -->
+
+- Total Sub-Issues:
+- Completed:
+- In Progress:
+- Blocked:
+
+## Additional Notes
+
+<!-- Add any other relevant information, dependencies, or references. -->


### PR DESCRIPTION
This pull request adds a new issue template specifically for hub (epic) issues to help centralize and track related sub-issues more efficiently.

Issue tracking improvements:

* Added a new `.github/ISSUE_TEMPLATE/hub_issue.md` file that provides a structured template for creating hub issues, including sections for sub-issues, context, expected outcomes, progress tracking, and additional notes.