### PR TITLE
GITHUB - changed hub to module

### DIFF
--- a/.github/ISSUE_TEMPLATE/module_issue.md
+++ b/.github/ISSUE_TEMPLATE/module_issue.md
@@ -1,14 +1,14 @@
 ---
-name: "Hub Issue"
-about: "Template for hub issues that serve as a central point for tracking multiple sub-issues."
-title: "[Hub] <short description>"
-labels: ["hub", "epic"]
+name: "Module Issue"
+about: "Template for module issues that serve as a central point for tracking multiple sub-issues."
+title: "[Module] <short description>"
+labels: ["module", "epic"]
 assignees: []
 ---
 
 ## Description
 
-<!-- Provide a high-level description of the hub issue and its purpose. -->
+<!-- Provide a high-level description of the module issue and its purpose. -->
 
 ## Sub-Issues
 
@@ -24,11 +24,11 @@ assignees: []
 
 ## Expected Outcome
 
-<!-- What is the overall goal or deliverable for this hub? -->
+<!-- What is the overall goal or deliverable for this module? -->
 
 ## Progress Tracking
 
-<!-- Track the overall progress of the hub. -->
+<!-- Track the overall progress of the module. -->
 
 - Total Sub-Issues:
 - Completed:


### PR DESCRIPTION
This pull request updates the issue template previously used for "hub" issues to instead be used for "module" issues. The changes are primarily focused on renaming and updating template language to reflect this new terminology.

Issue template update:

* Renamed the file from `.github/ISSUE_TEMPLATE/hub_issue.md` to `.github/ISSUE_TEMPLATE/module_issue.md` and updated all references from "hub" to "module" in the template fields, descriptions, and labels. [[1]](diffhunk://#diff-b02ca2dac00146e870ad2650c175283a7a209a8c989d914f03d8ed4c48867a4bL2-R11) [[2]](diffhunk://#diff-b02ca2dac00146e870ad2650c175283a7a209a8c989d914f03d8ed4c48867a4bL27-R31)