### PR TITLE
reffactor (CI/CD): Update the condition for the push to mirror so it …

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -163,8 +163,8 @@ jobs:
   push-to-mirror:
     name: Push to Mirror Repository
     needs: deploy-app
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.merged == true }}
-    environment: AREA
+    if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.merged == true) || (github.event_name == 'push' && contains(github.event.head_commit.message, 'Merge pull request')) }}
+    environment: PIPELINE
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Repository


### PR DESCRIPTION
…also check the name of the head so that the job stop being skipped
This pull request updates the workflow conditions and environment for the push-to-mirror job in the GitHub Actions CI/CD pipeline. The main goal is to ensure the job runs for both merged pull requests and direct merges to the main branch, and to update the deployment environment.

Workflow changes:

* Broadened the trigger condition for the `push-to-mirror` job to also run when a direct push contains a merge commit message, not just on merged pull requests.
* Changed the deployment environment for the `push-to-mirror` job from `AREA` to `PIPELINE`.