### PR TITLE
feat (CI/CD): Add new rule to the the co so that on merge all of the …

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -43,6 +43,17 @@ jobs:
           # Ensure we have the refs available
           git fetch --no-tags --prune --depth=1 origin || true
 
+          # If this push is a merge commit created by merging a PR, its commit
+          # message usually contains "Merge pull request" (or similar). Treat
+          # that as a PR-merge and run all jobs.
+          commit_message=$(git log -1 --pretty=%B "${{ github.sha }}" 2>/dev/null || true)
+          if echo "$commit_message" | grep -qE 'Merge pull request|Merged in|Merge branch'; then
+            echo "Detected merge commit: $commit_message" >&2
+            echo "backend_changed=true" >> "$GITHUB_OUTPUT"
+            echo "web_changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
             changed_files=$(git ls-tree -r --name-only "$AFTER")
           else


### PR DESCRIPTION
…job starts
This pull request updates the CI/CD workflow to better detect when a push is the result of merging a pull request. The main improvement is that the workflow now checks the commit message for typical merge patterns and, if detected, triggers all relevant jobs to ensure comprehensive testing and deployment.

**CI/CD workflow enhancements:**

* Added logic in `.github/workflows/cicd.yml` to detect merge commits by checking for phrases like "Merge pull request" in the commit message. When such a commit is found, all jobs are triggered by setting `backend_changed` and `web_changed` to true.