### PR TITLE
upt (CI/CD): Upadte the path used in the push to mirror

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -183,7 +183,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Push to Mirror Repository
-        uses: pixtal/github-repo-mirror-action@v2
+        uses: pixta-dev/repository-mirroring-action@v1
         with:
           target_repo: ${{ secrets.MIRROR_REPO }}
           ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}


### PR DESCRIPTION
This pull request updates the mirroring action used in the CI/CD workflow to a new repository and version. This change ensures that the workflow uses the maintained and intended mirroring action.

- **CI/CD Workflow Update:**
  * [`.github/workflows/cicd.yml`](diffhunk://#diff-6727e33ccc9195d67f0786e1384f8f1cdaf4090c3e77547943105bd2b28c99d0L186-R186): Replaced the `pixtal/github-repo-mirror-action@v2` with `pixta-dev/repository-mirroring-action@v1` for the "Push to Mirror Repository" step.