### PR TITLE
bug (CI/CD): Update the name of the path used in the push to mirror s…

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -185,5 +185,5 @@ jobs:
       - name: Push to Mirror Repository
         uses: pixta-dev/repository-mirroring-action@v1
         with:
-          target_repo: ${{ secrets.MIRROR_REPO }}
+          target_repo_url: ${{ secrets.MIRROR_REPO }}
           ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}


### PR DESCRIPTION
…o that it uses the convetional ones
This pull request makes a small change to the CI/CD workflow configuration by updating the input key for the repository mirroring action to use the correct parameter name. 

- In `.github/workflows/cicd.yml`, changed the input from `target_repo` to `target_repo_url` for the `pixta-dev/repository-mirroring-action` step to match the expected input parameter.