### PR TITLE
feat (CI/CD): Add a verification of secrets before trying to push to …

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -182,8 +182,27 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Validate mirror repo secret
+        run: |
+          echo "Checking MIRROR_REPO secret..."
+          if [ -z "${MIRROR_REPO}" ]; then
+            echo "::error::secrets.MIRROR_REPO is empty"
+            exit 1
+          fi
+          # Basic SSH URL sanity check (git@host:owner/repo.git)
+          if ! echo "${MIRROR_REPO}" | grep -Eq '^[^@]+@[^:]+:[^/]+/.+(\.git)?$'; then
+            echo "::warning::secrets.MIRROR_REPO does not look like an SSH URL (expected git@host:owner/repo.git)."
+          fi
+          if [ -z "${SSH_PRIVATE_KEY}" ]; then
+            echo "::error::secrets.SSH_PRIVATE_KEY is empty"
+            exit 1
+          fi
+        env:
+          MIRROR_REPO: ${{ secrets.MIRROR_REPO }}
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Push to Mirror Repository
         uses: pixta-dev/repository-mirroring-action@v1
         with:
           target_repo_url: ${{ secrets.MIRROR_REPO }}
           ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh_username: git


### PR DESCRIPTION
…mirror
This pull request adds a validation step in the CI/CD workflow to check that the mirror repository secrets are present and correctly formatted before attempting to push to the mirror repository. This helps prevent failures due to missing or misconfigured secrets.

Secret validation improvements:

* Added a new step in `.github/workflows/cicd.yml` to check that the `MIRROR_REPO` and `SSH_PRIVATE_KEY` secrets are set, and to provide clear error messages if they are missing. Also included a basic sanity check to ensure `MIRROR_REPO` looks like a valid SSH URL.

Repository mirroring configuration:

* Updated the mirror push step to explicitly set `ssh_username: git` for the mirroring action.