### PR TITLE
backend - define mapping format

### DIFF
--- a/backend/src/config/entity/WebhookConfigs.ts
+++ b/backend/src/config/entity/WebhookConfigs.ts
@@ -5,6 +5,7 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import type { Action, Reaction } from '../../types/mapping';
 
 @Entity('webhook_configs')
 export class WebhookConfigs {
@@ -14,11 +15,11 @@ export class WebhookConfigs {
   @Column({ type: 'varchar', length: 100, unique: true })
   name!: string;
 
-  @Column({ type: 'varchar', length: 100 })
-  action_type!: string;
+  @Column({ type: 'jsonb' })
+  action!: Action;
 
-  @Column({ type: 'text', array: true })
-  reactions!: string[];
+  @Column({ type: 'jsonb', array: true })
+  reactions!: Reaction[];
 
   @Column({ type: 'boolean', default: true })
   is_active!: boolean;

--- a/backend/src/types/mapping.ts
+++ b/backend/src/types/mapping.ts
@@ -36,7 +36,7 @@ export const MAPPING_VALIDATION_RULES = {
   action: {
     type: {
       required: true,
-      pattern: /^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$/, /* service.action format */
+      pattern: /^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$/ /* service.action format */,
     },
     config: {
       type: 'object',
@@ -51,7 +51,8 @@ export const MAPPING_VALIDATION_RULES = {
       properties: {
         type: {
           required: true,
-          pattern: /^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$/, /* service.reaction format */
+          pattern:
+            /^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$/ /* service.reaction format */,
         },
         config: {
           type: 'object',

--- a/backend/src/types/mapping.ts
+++ b/backend/src/types/mapping.ts
@@ -1,0 +1,93 @@
+// Mapping types for AREA Action-Reaction system
+// This file defines the standard format for storing and mapping Actions to Reactions
+
+export interface Action {
+  type: string;
+  config: Record<string, unknown>;
+}
+
+export interface Reaction {
+  type: string;
+  config: Record<string, unknown>;
+}
+
+export interface ActionReactionMapping {
+  id: number;
+  name: string;
+
+  action: Action;
+  reactions: Reaction[];
+
+  is_active: boolean;
+  description?: string;
+
+  created_by: number;
+  created_at: Date;
+  updated_at: Date;
+}
+
+/* Validation rules for ActionReactionMapping */
+export const MAPPING_VALIDATION_RULES = {
+  name: {
+    maxLength: 100,
+    required: true,
+    unique: true,
+  },
+  action: {
+    type: {
+      required: true,
+      pattern: /^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$/, // service.action format
+    },
+    config: {
+      type: 'object',
+      required: true,
+    },
+  },
+  reactions: {
+    type: 'array',
+    minItems: 1,
+    items: {
+      type: 'object',
+      properties: {
+        type: {
+          required: true,
+          pattern: /^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$/, // service.reaction format
+        },
+        config: {
+          type: 'object',
+          required: true,
+        },
+      },
+    },
+  },
+};
+
+/* Field types for configuration schemas */
+export type FieldType =
+  | 'text'
+  | 'email'
+  | 'textarea'
+  | 'select'
+  | 'checkbox'
+  | 'number';
+
+export interface SelectOption {
+  value: string;
+  label: string;
+}
+
+export interface ConfigField {
+  name: string;
+  type: FieldType;
+  label: string;
+  required: boolean;
+  placeholder?: string;
+  options?: SelectOption[];
+  default?: string | number | boolean;
+}
+
+export interface ActionReactionSchema {
+  name: string;
+  description?: string;
+  fields: ConfigField[];
+}

--- a/backend/src/types/mapping.ts
+++ b/backend/src/types/mapping.ts
@@ -23,7 +23,7 @@ export interface ActionReactionMapping {
 
   created_by: number;
   created_at: Date;
-  updated_at: Date;
+  updated_at?: Date;
 }
 
 /* Validation rules for ActionReactionMapping */
@@ -36,7 +36,7 @@ export const MAPPING_VALIDATION_RULES = {
   action: {
     type: {
       required: true,
-      pattern: /^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$/, // service.action format
+      pattern: /^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$/, /* service.action format */
     },
     config: {
       type: 'object',
@@ -51,7 +51,7 @@ export const MAPPING_VALIDATION_RULES = {
       properties: {
         type: {
           required: true,
-          pattern: /^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$/, // service.reaction format
+          pattern: /^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$/, /* service.reaction format */
         },
         config: {
           type: 'object',

--- a/database/table/webhook_configs.sql
+++ b/database/table/webhook_configs.sql
@@ -6,8 +6,8 @@
 CREATE TABLE webhook_configs (
     "id" SERIAL PRIMARY KEY,
     "name" VARCHAR(100) UNIQUE NOT NULL,
-    "action_type" VARCHAR(100) NOT NULL,
-    "reactions" TEXT[] NOT NULL,
+    "action" JSONB NOT NULL,
+    "reactions" JSONB[] NOT NULL,
     "is_active" BOOLEAN DEFAULT TRUE,
     "description" TEXT,
     "created_by" INTEGER,


### PR DESCRIPTION
This pull request refactors how actions and reactions are stored and represented for webhook configurations in the backend. Instead of using simple string types, actions and reactions are now modeled as structured JSON objects, allowing for richer configuration and validation. The changes also introduce new TypeScript interfaces and validation rules to standardize the format for these mappings.

**Data model and database schema improvements:**

* Changed the `action_type` and `reactions` columns in both the `WebhookConfigs` entity (`WebhookConfigs.ts`) and the database schema (`webhook_configs.sql`) to use structured JSON objects (`action: Action`, `reactions: Reaction[]`) instead of strings, enabling more flexible and descriptive configuration. [[1]](diffhunk://#diff-bb222c1245c86ac230e7ba475fb49be051ece99d536ca191d0daf800e8c290adL17-R22) [[2]](diffhunk://#diff-a1942c7ae1d3d2353ffaa89d742b3555c746b3b111d99df7a893ad2051e81fc0L9-R10)

**Type definitions and validation:**

* Added new TypeScript interfaces (`Action`, `Reaction`, `ActionReactionMapping`) and validation rules in `mapping.ts` to define and enforce the standard format for storing and mapping actions to reactions, including field types and configuration schemas.
* Updated imports in `WebhookConfigs.ts` to reference the new `Action` and `Reaction` types for type safety.