### PR TITLE
feat (CICD): Refactor secret env and update web deployment

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -146,12 +146,14 @@ jobs:
           DB_NAME: ${{ secrets.DB_NAME }}
           DB_PORT: ${{ secrets.DB_PORT }}
           NODE_PORT: ${{ secrets.NODE_PORT }}
+          NEXT_PORT: ${{ secrets.NEXT_PORT }}
         run: |
           echo "DB_USER=$DB_USER" > ./deployment/.env
           echo "DB_PASSWORD=$DB_PASSWORD" >> ./deployment/.env
           echo "DB_NAME=$DB_NAME" >> ./deployment/.env
           echo "DB_PORT=$DB_PORT" >> ./deployment/.env
           echo "NODE_PORT=$NODE_PORT" >> ./deployment/.env
+          echo "NEXT_PORT=$NEXT_PORT" >> ./deployment/.env
 
       - name: Clean all containers
         run: docker compose -f ./deployment/docker-compose.yml down -v
@@ -165,8 +167,8 @@ jobs:
       - name: Waiting for backend service
         run: timeout 60 bash -c 'until nc -z localhost ${{ secrets.NODE_PORT }}; do sleep 2; done'
 
-      # - name: Waiting for web service
-      #   run: timeout 60 bash -c 'until nc -z localhost ${{ secrets.WEB_PORT }}; do sleep 2; done'
+      - name: Waiting for web service
+        run: timeout 60 bash -c 'until nc -z localhost ${{ secrets.NEXT_PORT }}; do sleep 2; done'
 
       - name: List running containers
         run: docker ps


### PR DESCRIPTION
This pull request updates the CI/CD workflow configuration to support the `NEXT_PORT` environment variable for the web service, replacing the previous use of `WEB_PORT`. The changes ensure that the correct port is set and waited for during deployment.

**Environment variable updates:**

* Added `NEXT_PORT` to the environment variables written to `deployment/.env` in the `.github/workflows/cicd.yml` file.

**Service health check updates:**

* Changed the web service health check to use `NEXT_PORT` instead of the previously commented out `WEB_PORT`, ensuring the workflow waits for the correct web service port to be available.