### PR TITLE
fix (backend): added /api to webhooks route

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -63,8 +63,8 @@ app.use('/api/user', userRoutes);
 app.use('/api/github', githubRoutes);
 app.use('/api/services', serviceConfigRoutes);
 app.use('/api/info', apiRoutes);
+app.use('/api/webhooks', webhookRoutes);
 app.use('/about.json', aboutRoutes);
-app.use('/webhooks', webhookRoutes);
 
 setupSwagger(app);
 setupSignal();


### PR DESCRIPTION
This pull request updates the route registration for webhook-related endpoints in the `backend/index.ts` file. The main change is that the webhook routes are now served under the `/api/webhooks` path to be consistent with other API endpoints.

Routing consistency:

* Registered `webhookRoutes` under `/api/webhooks` instead of `/webhooks`, aligning webhook endpoints with the `/api` prefix used for other routes.