### PR TITLE
fix (backend): translations

### DIFF
--- a/backend/src/config/i18n.ts
+++ b/backend/src/config/i18n.ts
@@ -37,6 +37,6 @@ export const initI18n = async (): Promise<void> => {
     console.error('Error initializing i18n:', error);
     throw error;
   }
-};;;;;
+};
 
 export default i18next;

--- a/backend/src/config/i18n.ts
+++ b/backend/src/config/i18n.ts
@@ -8,28 +8,35 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 export const initI18n = async (): Promise<void> => {
-  await i18next
-    .use(Backend)
-    .use(LanguageDetector)
-    .init({
-      fallbackLng: 'en',
-      lng: 'en',
-      ns: ['translation'],
-      defaultNS: 'translation',
-      backend: {
-        loadPath: path.join(__dirname, '../../locales/{{lng}}.json'),
-      },
-      detection: {
-        order: ['header', 'querystring', 'cookie'],
-        lookupHeader: 'accept-language',
-        lookupQuerystring: 'lang',
-        lookupCookie: 'i18next',
-        caches: ['cookie'],
-      },
-      interpolation: {
-        escapeValue: false,
-      },
-    });
-};
+  try {
+    const localesPath = path.join(__dirname, '../../locales/{{lng}}.json');
+
+    await i18next
+      .use(Backend)
+      .use(LanguageDetector)
+      .init({
+        fallbackLng: 'en',
+        lng: 'en',
+        supportedLngs: ['en', 'fr'],
+        preload: ['en', 'fr'],
+        backend: {
+          loadPath: localesPath,
+        },
+        detection: {
+          order: ['header', 'querystring', 'cookie'],
+          lookupHeader: 'accept-language',
+          lookupQuerystring: 'lang',
+          lookupCookie: 'i18next',
+          caches: ['cookie'],
+        },
+        interpolation: {
+          escapeValue: false,
+        },
+      });
+  } catch (error) {
+    console.error('Error initializing i18n:', error);
+    throw error;
+  }
+};;;;;
 
 export default i18next;

--- a/backend/src/routes/about/about.ts
+++ b/backend/src/routes/about/about.ts
@@ -71,6 +71,9 @@ router.get('/', async (req: Request, res: Response): Promise<void> => {
 
     const currentTime = Math.floor(Date.now() / 1000);
 
+    const lang = (req.query.lang as string) || 'en';
+    await i18next.changeLanguage(lang);
+
     const services = serviceRegistry.getAllServices().map(service => {
       const translatedService = translateService(service, i18next.t);
       return {


### PR DESCRIPTION
This pull request improves internationalization support and error handling in the backend, and adds dynamic language selection for the About route. The most important changes are grouped below:

**Internationalization Improvements:**

* Added support for French by updating `i18next` configuration with `supportedLngs` and `preload` options, allowing both English and French translations to be loaded.
* Refactored the i18n initialization to use a variable for the locales path, making the code more maintainable.

**Error Handling:**

* Wrapped the i18n initialization in a try-catch block to log and rethrow errors if initialization fails, improving reliability and debuggability.

**Dynamic Language Selection:**

* Updated the About route to allow clients to specify a language via the `lang` query parameter, and set the translation language dynamically based on this parameter.