### PR TITLE
Connected profile, login, logout, register and forgot password to the backend

### DIFF
--- a/backend/src/routes/auth/auth.ts
+++ b/backend/src/routes/auth/auth.ts
@@ -681,7 +681,7 @@ router.post('/forgot-password', async (req: Request, res: Response) => {
     };
 
     await transporter.sendMail(mailOptions);
-    res.status(201).json({
+    res.status(200).json({
       message:
         'If that email is registered, you will receive a password reset link.',
     });

--- a/mobile/lib/core/constants/app_colors.dart
+++ b/mobile/lib/core/constants/app_colors.dart
@@ -10,6 +10,7 @@ class AppColors {
   static const Color background = Color(0xFFE4E2DD); // HEX: #e4e2dd
   static const Color surface = Color(0xFFFFFFFF); // White surface
   static const Color error = Color(0xFFF44336); // Error red
+  static const Color success = Color(0xFF4CAF50); // Success green
 
   static const Color textPrimary = Color(0xFF000000); // HEX: #000000
   static const Color textSecondary = Color(0xFF45433E); // HEX: #45433E

--- a/mobile/lib/core/constants/app_constants.dart
+++ b/mobile/lib/core/constants/app_constants.dart
@@ -7,6 +7,9 @@ class AppRoutes {
   static const String register = "api/auth/register";
   static const String logout = "api/auth/logout";
   static const String forgotPassword = "api/auth/forgot-password";
+
+  // Profile
+  static const String me = "api/user/me";
 }
 
 class AppDimensions {

--- a/mobile/lib/core/constants/app_constants.dart
+++ b/mobile/lib/core/constants/app_constants.dart
@@ -1,5 +1,12 @@
 class AppRoutes {
+  // Api health
   static const String healthCheck = "api/info/health";
+
+  // Auth
+  static const String login = "api/auth/login";
+  static const String register = "api/auth/register";
+  static const String logout = "api/auth/logout";
+  static const String forgotPassword = "api/auth/forgot-password";
 }
 
 class AppDimensions {

--- a/mobile/lib/core/constants/app_constants.dart
+++ b/mobile/lib/core/constants/app_constants.dart
@@ -1,4 +1,6 @@
-class AppRoutes {}
+class AppRoutes {
+  static const String healthCheck = "api/info/health";
+}
 
 class AppDimensions {
   // Padding & Margins

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -29,5 +29,7 @@
   "empty_backend_server_address": "Please enter a backend server address",
   "invalid_backend_server_address": "The address is not valid",
   "valid_backend_server_address": "The address is valid",
-  "user_registered": "User registered"
+  "user_registered": "User registered",
+  "logged_in": "Logged in successfully",
+  "logged_out": "Logged out successfully"
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -25,5 +25,8 @@
   "empty_name": "Please enter your name",
   "invalid_name": "Name must be less than 38 characters",
   "confirm_password": "Confirm Password",
-  "confirm_password_differs": "Passwords differ"
+  "confirm_password_differs": "Passwords differ",
+  "empty_backend_server_address": "The address cannot be empty",
+  "invalid_backend_server_address": "The address is not valid",
+  "valid_backend_server_address": "The address is valid"
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -26,7 +26,8 @@
   "invalid_name": "Name must be less than 38 characters",
   "confirm_password": "Confirm Password",
   "confirm_password_differs": "Passwords differ",
-  "empty_backend_server_address": "The address cannot be empty",
+  "empty_backend_server_address": "Please enter a backend server address",
   "invalid_backend_server_address": "The address is not valid",
-  "valid_backend_server_address": "The address is valid"
+  "valid_backend_server_address": "The address is valid",
+  "user_registered": "User registered"
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -26,7 +26,8 @@
   "invalid_name": "Le nom doit contenir moins de 38 caractères",
   "confirm_password": "Confirmer le mot de passe",
   "confirm_password_differs": "Les mots de passe ne correspondent pas",
-  "empty_backend_server_address": "L'adresse ne peut pas être vide",
+  "empty_backend_server_address": "Entrez une adresse du serveur backend",
   "invalid_backend_server_address": "L'adresse n'est pas valide",
-  "valid_backend_server_address": "L'adresse est valide"
+  "valid_backend_server_address": "L'adresse est valide",
+  "user_registered": "Utilisateur créé"
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -25,5 +25,8 @@
   "empty_name": "Entrez votre nom",
   "invalid_name": "Le nom doit contenir moins de 38 caractères",
   "confirm_password": "Confirmer le mot de passe",
-  "confirm_password_differs": "Les mots de passe ne correspondent pas"
+  "confirm_password_differs": "Les mots de passe ne correspondent pas",
+  "empty_backend_server_address": "L'adresse ne peut pas être vide",
+  "invalid_backend_server_address": "L'adresse n'est pas valide",
+  "valid_backend_server_address": "L'adresse est valide"
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -29,5 +29,7 @@
   "empty_backend_server_address": "Entrez une adresse du serveur backend",
   "invalid_backend_server_address": "L'adresse n'est pas valide",
   "valid_backend_server_address": "L'adresse est valide",
-  "user_registered": "Utilisateur créé"
+  "user_registered": "Utilisateur créé",
+  "logged_in": "Connexion réussie",
+  "logged_out": "Déconnexion réussie"
 }

--- a/mobile/lib/l10n/app_localizations.dart
+++ b/mobile/lib/l10n/app_localizations.dart
@@ -257,7 +257,7 @@ abstract class AppLocalizations {
   /// No description provided for @empty_backend_server_address.
   ///
   /// In en, this message translates to:
-  /// **'The address cannot be empty'**
+  /// **'Please enter a backend server address'**
   String get empty_backend_server_address;
 
   /// No description provided for @invalid_backend_server_address.
@@ -271,6 +271,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'The address is valid'**
   String get valid_backend_server_address;
+
+  /// No description provided for @user_registered.
+  ///
+  /// In en, this message translates to:
+  /// **'User registered'**
+  String get user_registered;
 }
 
 class _AppLocalizationsDelegate

--- a/mobile/lib/l10n/app_localizations.dart
+++ b/mobile/lib/l10n/app_localizations.dart
@@ -253,6 +253,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Passwords differ'**
   String get confirm_password_differs;
+
+  /// No description provided for @empty_backend_server_address.
+  ///
+  /// In en, this message translates to:
+  /// **'The address cannot be empty'**
+  String get empty_backend_server_address;
+
+  /// No description provided for @invalid_backend_server_address.
+  ///
+  /// In en, this message translates to:
+  /// **'The address is not valid'**
+  String get invalid_backend_server_address;
+
+  /// No description provided for @valid_backend_server_address.
+  ///
+  /// In en, this message translates to:
+  /// **'The address is valid'**
+  String get valid_backend_server_address;
 }
 
 class _AppLocalizationsDelegate

--- a/mobile/lib/l10n/app_localizations.dart
+++ b/mobile/lib/l10n/app_localizations.dart
@@ -277,6 +277,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'User registered'**
   String get user_registered;
+
+  /// No description provided for @logged_in.
+  ///
+  /// In en, this message translates to:
+  /// **'Logged in successfully'**
+  String get logged_in;
+
+  /// No description provided for @logged_out.
+  ///
+  /// In en, this message translates to:
+  /// **'Logged out successfully'**
+  String get logged_out;
 }
 
 class _AppLocalizationsDelegate

--- a/mobile/lib/l10n/app_localizations_en.dart
+++ b/mobile/lib/l10n/app_localizations_en.dart
@@ -98,4 +98,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get user_registered => 'User registered';
+
+  @override
+  String get logged_in => 'Logged in successfully';
+
+  @override
+  String get logged_out => 'Logged out successfully';
 }

--- a/mobile/lib/l10n/app_localizations_en.dart
+++ b/mobile/lib/l10n/app_localizations_en.dart
@@ -85,4 +85,13 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get confirm_password_differs => 'Passwords differ';
+
+  @override
+  String get empty_backend_server_address => 'The address cannot be empty';
+
+  @override
+  String get invalid_backend_server_address => 'The address is not valid';
+
+  @override
+  String get valid_backend_server_address => 'The address is valid';
 }

--- a/mobile/lib/l10n/app_localizations_en.dart
+++ b/mobile/lib/l10n/app_localizations_en.dart
@@ -87,11 +87,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get confirm_password_differs => 'Passwords differ';
 
   @override
-  String get empty_backend_server_address => 'The address cannot be empty';
+  String get empty_backend_server_address =>
+      'Please enter a backend server address';
 
   @override
   String get invalid_backend_server_address => 'The address is not valid';
 
   @override
   String get valid_backend_server_address => 'The address is valid';
+
+  @override
+  String get user_registered => 'User registered';
 }

--- a/mobile/lib/l10n/app_localizations_fr.dart
+++ b/mobile/lib/l10n/app_localizations_fr.dart
@@ -100,4 +100,10 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get user_registered => 'Utilisateur créé';
+
+  @override
+  String get logged_in => 'Connexion réussie';
+
+  @override
+  String get logged_out => 'Déconnexion réussie';
 }

--- a/mobile/lib/l10n/app_localizations_fr.dart
+++ b/mobile/lib/l10n/app_localizations_fr.dart
@@ -87,4 +87,13 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get confirm_password_differs =>
       'Les mots de passe ne correspondent pas';
+
+  @override
+  String get empty_backend_server_address => 'L\'adresse ne peut pas être vide';
+
+  @override
+  String get invalid_backend_server_address => 'L\'adresse n\'est pas valide';
+
+  @override
+  String get valid_backend_server_address => 'L\'adresse est valide';
 }

--- a/mobile/lib/l10n/app_localizations_fr.dart
+++ b/mobile/lib/l10n/app_localizations_fr.dart
@@ -89,11 +89,15 @@ class AppLocalizationsFr extends AppLocalizations {
       'Les mots de passe ne correspondent pas';
 
   @override
-  String get empty_backend_server_address => 'L\'adresse ne peut pas être vide';
+  String get empty_backend_server_address =>
+      'Entrez une adresse du serveur backend';
 
   @override
   String get invalid_backend_server_address => 'L\'adresse n\'est pas valide';
 
   @override
   String get valid_backend_server_address => 'L\'adresse est valide';
+
+  @override
+  String get user_registered => 'Utilisateur créé';
 }

--- a/mobile/lib/navigation/main_navigation.dart
+++ b/mobile/lib/navigation/main_navigation.dart
@@ -34,7 +34,7 @@ class MainNavigationState extends State<MainNavigation> {
 
   @override
   Widget build(BuildContext context) {
-    late final List<NavigationItem> _pages = [
+    late final List<NavigationItem> pages = [
       NavigationItem(
         label: AppLocalizations.of(context)!.label_home,
         icon: Icons.home_outlined,
@@ -68,7 +68,7 @@ class MainNavigationState extends State<MainNavigation> {
     ];
 
     return Scaffold(
-      body: _pages[_currentIndex].screen,
+      body: pages[_currentIndex].screen,
       bottomNavigationBar: BottomNavigationBar(
         currentIndex: _currentIndex,
         onTap: (index) => setState(() => _currentIndex = index),
@@ -78,7 +78,7 @@ class MainNavigationState extends State<MainNavigation> {
           size: AppDimensions.iconSizeLG,
         ),
         selectedLabelStyle: const TextStyle(fontSize: 12, fontWeight: FontWeight.w600),
-        items: _pages
+        items: pages
             .map(
               (item) => BottomNavigationBarItem(
                 icon: Icon(item.icon),

--- a/mobile/lib/screens/add_automation_screen.dart
+++ b/mobile/lib/screens/add_automation_screen.dart
@@ -23,15 +23,21 @@ class AddAutomationScreenState extends State<AddAutomationScreen> {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.center,
-        spacing: 100,
+        spacing: 75,
         children: [
           SizedBox(
-            height: 250,
+            height: 300,
             child: Wrap(
               direction: Axis.vertical,
               alignment: WrapAlignment.end,
               crossAxisAlignment: WrapCrossAlignment.center,
-              children: [Image(image: AssetImage('assets/web-app-manifest-192x192.png'))],
+              children: [
+                Image(
+                  image: AssetImage('assets/web-app-manifest-512x512.png'),
+                  width: 200,
+                  height: 200,
+                ),
+              ],
             ),
           ),
           Wrap(

--- a/mobile/lib/screens/forgot_password_screen.dart
+++ b/mobile/lib/screens/forgot_password_screen.dart
@@ -1,6 +1,12 @@
+import 'dart:convert';
+
 import 'package:area/core/constants/app_colors.dart';
+import 'package:area/core/constants/app_constants.dart';
+import 'package:area/core/notifiers/backend_address_notifier.dart';
 import 'package:area/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:http/http.dart' as http;
 
 class ForgotPasswordScreen extends StatefulWidget {
   const ForgotPasswordScreen({super.key});
@@ -14,6 +20,8 @@ class ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
   final _emailController = TextEditingController();
   final _confirmEmailController = TextEditingController();
 
+  bool loading = false;
+
   @override
   void dispose() {
     _emailController.dispose();
@@ -21,14 +29,72 @@ class ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
     super.dispose();
   }
 
-  void _submitForm() {
+  void _submitForm() async {
+    setState(() {
+      loading = true;
+    });
     if (_formKey.currentState!.validate()) {
       String email = _emailController.text;
 
-      print('Email: $email');
+      final backendAddressNotifier = Provider.of<BackendAddressNotifier>(
+        context,
+        listen: false,
+      );
 
-      Navigator.pop(context);
+      if (backendAddressNotifier.backendAddress == null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              AppLocalizations.of(context)!.empty_backend_server_address,
+              style: TextStyle(color: AppColors.areaLightGray, fontSize: 16),
+            ),
+            backgroundColor: AppColors.error,
+          ),
+        );
+        setState(() {
+          loading = false;
+        });
+        return;
+      }
+
+      try {
+        final address = "${backendAddressNotifier.backendAddress}${AppRoutes.forgotPassword}";
+        final url = Uri.parse(address);
+
+        final response = await http.post(url, body: {'email': email});
+
+        final data = await jsonDecode(response.body);
+
+        if (response.statusCode != 200 && response.statusCode != 201) {
+          throw data['error'];
+        }
+
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              "Email sent",
+              style: TextStyle(color: AppColors.areaLightGray, fontSize: 16),
+            ),
+            backgroundColor: AppColors.success,
+          ),
+        );
+
+        Navigator.pop(context);
+      } catch (e) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              e.toString(),
+              style: TextStyle(color: AppColors.areaLightGray, fontSize: 16),
+            ),
+            backgroundColor: AppColors.error,
+          ),
+        );
+      }
     }
+    setState(() {
+      loading = false;
+    });
   }
 
   @override
@@ -91,17 +157,21 @@ class ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
 
               const SizedBox(height: 32),
 
-              ElevatedButton(
-                onPressed: _submitForm,
-                style: ElevatedButton.styleFrom(
-                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-                  backgroundColor: AppColors.primary,
+              if (loading) ...[
+                const CircularProgressIndicator(),
+              ] else ...[
+                ElevatedButton(
+                  onPressed: _submitForm,
+                  style: ElevatedButton.styleFrom(
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+                    backgroundColor: AppColors.primary,
+                  ),
+                  child: Text(
+                    AppLocalizations.of(context)!.send,
+                    style: TextStyle(color: AppColors.areaLightGray),
+                  ),
                 ),
-                child: Text(
-                  AppLocalizations.of(context)!.send,
-                  style: TextStyle(color: AppColors.areaLightGray),
-                ),
-              ),
+              ],
             ],
           ),
         ),

--- a/mobile/lib/screens/forgot_password_screen.dart
+++ b/mobile/lib/screens/forgot_password_screen.dart
@@ -65,7 +65,7 @@ class ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
 
         final data = await jsonDecode(response.body);
 
-        if (response.statusCode != 200 && response.statusCode != 201) {
+        if (response.statusCode != 200) {
           throw data['error'];
         }
 

--- a/mobile/lib/screens/login_screen.dart
+++ b/mobile/lib/screens/login_screen.dart
@@ -4,6 +4,7 @@ import 'package:area/core/constants/app_colors.dart';
 import 'package:area/core/constants/app_constants.dart';
 import 'package:area/core/notifiers/backend_address_notifier.dart';
 import 'package:area/l10n/app_localizations.dart';
+import 'package:area/services/secure_storage.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:http/http.dart' as http;
@@ -70,7 +71,7 @@ class LoginScreenState extends State<LoginScreen> {
           throw data['error'];
         }
 
-        print(data['token']);
+        await saveJwt(data['token']);
 
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(

--- a/mobile/lib/screens/login_screen.dart
+++ b/mobile/lib/screens/login_screen.dart
@@ -94,10 +94,10 @@ class LoginScreenState extends State<LoginScreen> {
           ),
         );
       }
-      setState(() {
-        loading = false;
-      });
     }
+    setState(() {
+      loading = false;
+    });
   }
 
   @override
@@ -169,17 +169,21 @@ class LoginScreenState extends State<LoginScreen> {
                     ),
                     child: Text(AppLocalizations.of(context)!.forgot_password_question),
                   ),
-                  ElevatedButton(
-                    onPressed: _submitForm,
-                    style: ElevatedButton.styleFrom(
-                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-                      backgroundColor: AppColors.primary,
+                  if (loading) ...[
+                    const CircularProgressIndicator(),
+                  ] else ...[
+                    ElevatedButton(
+                      onPressed: _submitForm,
+                      style: ElevatedButton.styleFrom(
+                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+                        backgroundColor: AppColors.primary,
+                      ),
+                      child: Text(
+                        AppLocalizations.of(context)!.login,
+                        style: TextStyle(color: AppColors.areaLightGray),
+                      ),
                     ),
-                    child: Text(
-                      AppLocalizations.of(context)!.login,
-                      style: TextStyle(color: AppColors.areaLightGray),
-                    ),
-                  ),
+                  ],
                 ],
               ),
             ],

--- a/mobile/lib/screens/profile_screen.dart
+++ b/mobile/lib/screens/profile_screen.dart
@@ -48,6 +48,54 @@ class ProfileScreenState extends State<ProfileScreen> {
     }
   }
 
+  void _logout() async {
+    final backendAddressNotifier = Provider.of<BackendAddressNotifier>(context, listen: false);
+
+    if (backendAddressNotifier.backendAddress == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            AppLocalizations.of(context)!.empty_backend_server_address,
+            style: TextStyle(color: AppColors.areaLightGray, fontSize: 16),
+          ),
+          backgroundColor: AppColors.error,
+        ),
+      );
+      return;
+    }
+    final address = "${backendAddressNotifier.backendAddress}${AppRoutes.logout}";
+    final url = Uri.parse(address);
+    try {
+      final response = await http.post(url);
+
+      final data = await jsonDecode(response.body);
+
+      if (response.statusCode != 200) {
+        throw data['error'];
+      }
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            AppLocalizations.of(context)!.logged_out,
+            style: TextStyle(color: AppColors.areaLightGray, fontSize: 16),
+          ),
+          backgroundColor: AppColors.success,
+        ),
+      );
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            e.toString(),
+            style: TextStyle(color: AppColors.areaLightGray, fontSize: 16),
+          ),
+          backgroundColor: AppColors.error,
+        ),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final localeNotifier = Provider.of<LocaleNotifier>(context);
@@ -88,7 +136,7 @@ class ProfileScreenState extends State<ProfileScreen> {
                 if (_isConnected) ...[
                   TextButton(
                     onPressed: () {
-                      print("User logs out");
+                      _logout();
                       setState(() {
                         _isConnected = false;
                       });
@@ -105,13 +153,10 @@ class ProfileScreenState extends State<ProfileScreen> {
                       TextButton(
                         onPressed: () {
                           Navigator.pushNamed(context, '/login').then((result) {
-                            if (result != null &&
-                                result is List &&
-                                result.isNotEmpty &&
-                                result[0] == true) {
+                            if (result == true) {
                               setState(() {
                                 _isConnected = true;
-                                _userName = result[1] as String;
+                                _userName = "Connected";
                                 _userProfileIcon = Icons.account_circle;
                               });
                             }

--- a/mobile/lib/screens/register_screen.dart
+++ b/mobile/lib/screens/register_screen.dart
@@ -22,6 +22,8 @@ class RegisterScreenState extends State<RegisterScreen> {
   final _passwordController = TextEditingController();
   final _confirmPasswordController = TextEditingController();
 
+  bool loading = false;
+
   @override
   void dispose() {
     _nameController.dispose();
@@ -32,6 +34,9 @@ class RegisterScreenState extends State<RegisterScreen> {
   }
 
   void _submitForm() async {
+    setState(() {
+      loading = true;
+    });
     if (_formKey.currentState!.validate()) {
       String name = _nameController.text;
       String email = _emailController.text;
@@ -52,6 +57,9 @@ class RegisterScreenState extends State<RegisterScreen> {
             backgroundColor: AppColors.error,
           ),
         );
+        setState(() {
+          loading = false;
+        });
         return;
       }
 
@@ -92,6 +100,9 @@ class RegisterScreenState extends State<RegisterScreen> {
           ),
         );
       }
+      setState(() {
+        loading = false;
+      });
     }
   }
 
@@ -197,17 +208,21 @@ class RegisterScreenState extends State<RegisterScreen> {
 
               const SizedBox(height: 32),
 
-              ElevatedButton(
-                onPressed: _submitForm,
-                style: ElevatedButton.styleFrom(
-                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-                  backgroundColor: AppColors.primary,
+              if (loading) ...[
+                const CircularProgressIndicator(),
+              ] else ...[
+                ElevatedButton(
+                  onPressed: _submitForm,
+                  style: ElevatedButton.styleFrom(
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+                    backgroundColor: AppColors.primary,
+                  ),
+                  child: Text(
+                    AppLocalizations.of(context)!.register,
+                    style: TextStyle(color: AppColors.areaLightGray),
+                  ),
                 ),
-                child: Text(
-                  AppLocalizations.of(context)!.register,
-                  style: TextStyle(color: AppColors.areaLightGray),
-                ),
-              ),
+              ],
             ],
           ),
         ),

--- a/mobile/lib/services/secure_storage.dart
+++ b/mobile/lib/services/secure_storage.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+final FlutterSecureStorage _secureStorage = FlutterSecureStorage();
+
+Future<void> saveJwt(String token) async {
+  await _secureStorage.write(key: "jwt", value: token);
+}
+
+Future<String?> getJwt() async {
+  return await _secureStorage.read(key: "jwt");
+}
+
+Future<void> deleteJwt() async {
+  await _secureStorage.delete(key: "jwt");
+}

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -41,6 +41,8 @@ dependencies:
     sdk: flutter
   intl: ^0.20.2
 
+  flutter_secure_storage: ^9.1.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
This pull request introduces several improvements and new features to the mobile app's authentication and localization flows, along with minor UI updates. The most significant changes include adding backend communication for login and password reset, expanding localization support for new messages, and updating navigation and UI elements for consistency.

### Authentication and Backend Communication

* Implemented backend API calls for login and forgot password screens, including error handling, success feedback, and loading indicators. The screens now use the backend address from the app's state and display localized messages for various outcomes. (`mobile/lib/screens/login_screen.dart`, `mobile/lib/screens/forgot_password_screen.dart`) [[1]](diffhunk://#diff-f583be976999acff74d80e9416ae8a7a7102524d76902533bf75dd30f98eeef6R1-R10) [[2]](diffhunk://#diff-064b4f633ef86c9f0cb48de21f7b37f89b1fd9905e798b1eb2a19d6d1119e980R1-R9)
* Added new routes for authentication and profile endpoints in `AppRoutes`, centralizing API path management. (`mobile/lib/core/constants/app_constants.dart`)

### Localization Enhancements

* Added new localized strings for backend server address validation, user registration, login, and logout messages in both English and French ARB files, and exposed them in the localization Dart classes. (`mobile/lib/l10n/app_en.arb`, `mobile/lib/l10n/app_fr.arb`, `mobile/lib/l10n/app_localizations.dart`, `mobile/lib/l10n/app_localizations_en.dart`, `mobile/lib/l10n/app_localizations_fr.dart`) [[1]](diffhunk://#diff-f5fbe8a3bcaaef02aa26e9500caac80151382172ab77d8b4c4b2faeb68ef4f29L28-R34) [[2]](diffhunk://#diff-0c3deda39673c546e575049371068a6efbbd0b4368cdff3d769a102842174371L28-R34) [[3]](diffhunk://#diff-2b069ea38a86eeb57d315fd7432f9cf1786a65d3dfab7f8bbb41eecc79784efbR256-R291) [[4]](diffhunk://#diff-c4a3ff2e32e0b0e92e6fcee73b0bb849e7959e926ea554e09c6f2685121cb5bcR88-R106) [[5]](diffhunk://#diff-bcab71e3734c8d3c9168514b3ba25a0596431c3a6469e2ef991b6a8feac178ecR90-R108)

### UI and Navigation Updates

* Updated navigation variable naming in `MainNavigationState` for clarity and consistency, changing `_pages` to `pages`. (`mobile/lib/navigation/main_navigation.dart`) [[1]](diffhunk://#diff-ff907f48bd774d44fb277727b7304b6a0533ceedb5df413778ad5692d3f328e9L37-R37) [[2]](diffhunk://#diff-ff907f48bd774d44fb277727b7304b6a0533ceedb5df413778ad5692d3f328e9L71-R71) [[3]](diffhunk://#diff-ff907f48bd774d44fb277727b7304b6a0533ceedb5df413778ad5692d3f328e9L81-R81)
* Improved the UI of the add automation screen by adjusting spacing, image size, and asset used for better visual presentation. (`mobile/lib/screens/add_automation_screen.dart`)

### Theming and Feedback

* Added a new success color to `AppColors` for use in feedback messages. (`mobile/lib/core/constants/app_colors.dart`)

### Backend Response Handling

* Updated backend response code for the forgot password endpoint to use HTTP 200 instead of 201 for clarity and convention. (`backend/src/routes/auth/auth.ts`)