### PR TITLE
feat (backend): separated login from subscribe

### DIFF
--- a/backend/src/config/passport.ts
+++ b/backend/src/config/passport.ts
@@ -27,27 +27,6 @@ export interface GoogleUser {
   token: string;
 }
 
-async function isUserAuthenticated(req: Request): Promise<boolean> {
-  try {
-    const authHeader = req.header('Authorization');
-    if (authHeader && authHeader.startsWith('Bearer ')) {
-      const token = authHeader.replace('Bearer ', '');
-      jwt.verify(token, JWT_SECRET as string);
-      return true;
-    }
-
-    const cookieToken = req.cookies?.auth_token;
-    if (cookieToken) {
-      jwt.verify(cookieToken, JWT_SECRET as string);
-      return true;
-    }
-
-    return false;
-  } catch {
-    return false;
-  }
-}
-
 async function getCurrentUser(
   req: Request
 ): Promise<{ id: number; email: string } | null> {
@@ -78,12 +57,13 @@ async function getCurrentUser(
 }
 
 passport.use(
+  'github-login',
   new GitHubStrategy(
     {
       clientID: process.env.SERVICE_GITHUB_CLIENT_ID || '',
       clientSecret: process.env.SERVICE_GITHUB_CLIENT_SECRET || '',
       callbackURL: process.env.SERVICE_GITHUB_REDIRECT_URI || '',
-      scope: ['user:email', 'read:user'],
+      scope: ['user:email'],
       passReqToCallback: true,
     },
     async (
@@ -99,31 +79,27 @@ passport.use(
         user?: GitHubUser | null
       ) => void;
       try {
-        const isServiceConnection = await isUserAuthenticated(req);
-
-        let userToken: string | Error;
-
-        if (isServiceConnection) {
-          const currentUser = await getCurrentUser(req);
-          if (!currentUser) {
-            return doneCallback(new Error('User not authenticated'), null);
+        let userEmail = profile.emails?.[0]?.value || '';
+        if (userEmail.includes('@github.oauth') || !userEmail) {
+          try {
+            const emails = await githubOAuth.getUserEmails(accessToken);
+            const primaryEmail = emails.find(
+              email => email.primary && email.verified
+            );
+            if (primaryEmail) {
+              userEmail = primaryEmail.email;
+            }
+          } catch (error) {
+            console.warn('Failed to fetch GitHub user emails:', error);
           }
-
-          userToken = await connectOAuthProvider(
-            currentUser.id,
-            'github',
-            profile.id,
-            profile.emails?.[0]?.value || '',
-            profile.displayName || profile.username || ''
-          );
-        } else {
-          userToken = await oauthLogin(
-            'github',
-            profile.id,
-            profile.emails?.[0]?.value || '',
-            profile.displayName || profile.username || ''
-          );
         }
+
+        const userToken = await oauthLogin(
+          'github',
+          profile.id,
+          userEmail,
+          profile.displayName || profile.username || ''
+        );
 
         if (userToken instanceof Error) {
           return doneCallback(userToken, null);
@@ -132,7 +108,7 @@ passport.use(
         const tokenData = {
           access_token: accessToken,
           token_type: 'bearer',
-          scope: 'user:email,read:user',
+          scope: 'user:email',
         };
 
         const decoded = jwt.verify(userToken, JWT_SECRET as string) as {
@@ -143,7 +119,7 @@ passport.use(
         return doneCallback(null, {
           id: profile.id,
           name: profile.displayName || profile.username || '',
-          email: profile.emails?.[0]?.value || '',
+          email: userEmail,
           token: userToken,
         });
       } catch (error) {
@@ -154,6 +130,86 @@ passport.use(
 );
 
 passport.use(
+  'github-subscribe',
+  new GitHubStrategy(
+    {
+      clientID: process.env.SERVICE_GITHUB_CLIENT_ID || '',
+      clientSecret: process.env.SERVICE_GITHUB_CLIENT_SECRET || '',
+      callbackURL: process.env.SERVICE_GITHUB_REDIRECT_URI || '',
+      scope: ['user:email', 'repo'],
+      passReqToCallback: true,
+    },
+    async (
+      req: Request,
+      accessToken: string,
+      params: unknown,
+      refreshToken: string,
+      profile: Profile,
+      done: unknown
+    ) => {
+      const doneCallback = done as (
+        error: Error | null,
+        user?: GitHubUser | null
+      ) => void;
+      try {
+        const currentUser = await getCurrentUser(req);
+        if (!currentUser) {
+          return doneCallback(new Error('User not authenticated'), null);
+        }
+
+        let userEmail = profile.emails?.[0]?.value || '';
+        if (userEmail.includes('@github.oauth') || !userEmail) {
+          try {
+            const emails = await githubOAuth.getUserEmails(accessToken);
+            const primaryEmail = emails.find(
+              email => email.primary && email.verified
+            );
+            if (primaryEmail) {
+              userEmail = primaryEmail.email;
+            }
+          } catch (error) {
+            console.warn('Failed to fetch GitHub user emails:', error);
+          }
+        }
+
+        const userToken = await connectOAuthProvider(
+          currentUser.id,
+          'github',
+          profile.id,
+          userEmail,
+          profile.displayName || profile.username || ''
+        );
+
+        if (userToken instanceof Error) {
+          return doneCallback(userToken, null);
+        }
+
+        const tokenData = {
+          access_token: accessToken,
+          token_type: 'bearer',
+          scope: 'user:email,repo',
+        };
+
+        const decoded = jwt.verify(userToken, JWT_SECRET as string) as {
+          id: number;
+        };
+        await githubOAuth.storeUserToken(decoded.id, tokenData);
+
+        return doneCallback(null, {
+          id: profile.id,
+          name: profile.displayName || profile.username || '',
+          email: userEmail,
+          token: userToken,
+        });
+      } catch (error) {
+        return doneCallback(error as Error, null);
+      }
+    }
+  )
+);
+
+passport.use(
+  'google-login',
   new GoogleStrategy(
     {
       clientID: process.env.SERVICE_GOOGLE_CLIENT_ID || '',
@@ -175,35 +231,85 @@ passport.use(
         user?: GoogleUser | null
       ) => void;
       try {
-        const isServiceConnection = await isUserAuthenticated(req);
+        const userToken = await oauthLogin(
+          'google',
+          profile.id,
+          profile.emails?.[0]?.value || '',
+          profile.displayName ||
+            profile.name?.givenName + ' ' + profile.name?.familyName ||
+            ''
+        );
 
-        let userToken: string | Error;
-
-        if (isServiceConnection) {
-          const currentUser = await getCurrentUser(req);
-          if (!currentUser) {
-            return doneCallback(new Error('User not authenticated'), null);
-          }
-
-          userToken = await connectOAuthProvider(
-            currentUser.id,
-            'google',
-            profile.id,
-            profile.emails?.[0]?.value || '',
-            profile.displayName ||
-              profile.name?.givenName + ' ' + profile.name?.familyName ||
-              ''
-          );
-        } else {
-          userToken = await oauthLogin(
-            'google',
-            profile.id,
-            profile.emails?.[0]?.value || '',
-            profile.displayName ||
-              profile.name?.givenName + ' ' + profile.name?.familyName ||
-              ''
-          );
+        if (userToken instanceof Error) {
+          return doneCallback(userToken, null);
         }
+
+        const tokenData = {
+          access_token: accessToken,
+          token_type: 'bearer',
+          expires_in: params.expires_in || 3600,
+          refresh_token: refreshToken,
+          scope: 'openid email profile',
+        };
+
+        const decoded = jwt.verify(userToken, JWT_SECRET as string) as {
+          id: number;
+        };
+        await googleOAuth.storeUserToken(decoded.id, tokenData);
+
+        return doneCallback(null, {
+          id: profile.id,
+          name:
+            profile.displayName ||
+            profile.name?.givenName + ' ' + profile.name?.familyName ||
+            '',
+          email: profile.emails?.[0]?.value || '',
+          token: userToken,
+        });
+      } catch (error) {
+        return doneCallback(error as Error, null);
+      }
+    }
+  )
+);
+
+passport.use(
+  'google-subscribe',
+  new GoogleStrategy(
+    {
+      clientID: process.env.SERVICE_GOOGLE_CLIENT_ID || '',
+      clientSecret: process.env.SERVICE_GOOGLE_CLIENT_SECRET || '',
+      callbackURL: process.env.SERVICE_GOOGLE_REDIRECT_URI || '',
+      scope: ['openid', 'email', 'profile'],
+      passReqToCallback: true,
+    },
+    async (
+      req: Request,
+      accessToken: string,
+      refreshToken: string,
+      params: { expires_in?: number },
+      profile: GoogleProfile,
+      done: unknown
+    ) => {
+      const doneCallback = done as (
+        error: Error | null,
+        user?: GoogleUser | null
+      ) => void;
+      try {
+        const currentUser = await getCurrentUser(req);
+        if (!currentUser) {
+          return doneCallback(new Error('User not authenticated'), null);
+        }
+
+        const userToken = await connectOAuthProvider(
+          currentUser.id,
+          'google',
+          profile.id,
+          profile.emails?.[0]?.value || '',
+          profile.displayName ||
+            profile.name?.givenName + ' ' + profile.name?.familyName ||
+            ''
+        );
 
         if (userToken instanceof Error) {
           return doneCallback(userToken, null);

--- a/backend/src/services/services/github/oauth.ts
+++ b/backend/src/services/services/github/oauth.ts
@@ -21,6 +21,13 @@ export interface GitHubUser {
   email: string;
 }
 
+export interface GitHubUserEmail {
+  email: string;
+  verified: boolean;
+  primary: boolean;
+  visibility: string | null;
+}
+
 export class GitHubOAuth {
   private clientId: string;
   private clientSecret: string;
@@ -101,6 +108,24 @@ export class GitHubOAuth {
     }
 
     return (await response.json()) as GitHubUser;
+  }
+
+  async getUserEmails(accessToken: string): Promise<GitHubUserEmail[]> {
+    const response = await fetch(`${this.githubApiBaseUrl}/user/emails`, {
+      headers: {
+        Authorization: `token ${accessToken}`,
+        Accept: 'application/vnd.github.v3+json',
+        'User-Agent': 'AREA-App',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to get GitHub user emails: ${response.statusText}`
+      );
+    }
+
+    return (await response.json()) as GitHubUserEmail[];
   }
 
   async storeUserToken(

--- a/web/components/login-form.tsx
+++ b/web/components/login-form.tsx
@@ -55,15 +55,15 @@ export function LoginForm({
   };
 
   const signInWithGithub = async () => {
-    window.location.href = `${await getAPIUrl()}/auth/github`;
+    window.location.href = `${await getAPIUrl()}/auth/github/login`;
   };
 
   const signInWithGoogle = async () => {
-    window.location.href = `${await getAPIUrl()}/auth/google`;
+    window.location.href = `${await getAPIUrl()}/auth/google/login`;
   };
 
   const signInWithMeta = async () => {
-    window.location.href = `${await getAPIUrl()}/auth/meta`;
+    window.location.href = `${await getAPIUrl()}/auth/meta/login`;
   };
 
   return (


### PR DESCRIPTION
This pull request refactors the OAuth authentication flow for both GitHub and Google, separating login/register and service connection into distinct strategies and routes. It improves clarity and security by explicitly distinguishing between login and account linking, enhances email retrieval for GitHub users, and updates related API documentation and frontend integration.

**Authentication Strategy Refactor:**

* Introduced separate Passport strategies for login/register (`github-login`, `google-login`) and service connection (`github-subscribe`, `google-subscribe`), replacing the previous single-strategy approach. This allows explicit control over authentication flows depending on user state. [[1]](diffhunk://#diff-25c35c799a1700794d71dc5369f3ab64bf6f2f63693ec819cfa051a24413124fR60-R66) [[2]](diffhunk://#diff-25c35c799a1700794d71dc5369f3ab64bf6f2f63693ec819cfa051a24413124fR212) [[3]](diffhunk://#diff-25c35c799a1700794d71dc5369f3ab64bf6f2f63693ec819cfa051a24413124fL178-R304)

**OAuth Callback and Routing Updates:**

* Updated OAuth callback endpoints to dynamically select the appropriate strategy based on user authentication status, ensuring correct handling for both login/register and account linking scenarios. [[1]](diffhunk://#diff-278b414c47d2934820f3d227a5faa32d485d5e46baa854fe8317b38ee9f5609fL512-R535) [[2]](diffhunk://#diff-278b414c47d2934820f3d227a5faa32d485d5e46baa854fe8317b38ee9f5609fL606-R705)
* Added new API routes (`/auth/github/login`, `/auth/github/subscribe`, `/auth/google/login`, `/auth/google/subscribe`) and updated Swagger documentation to clearly describe their purposes and authentication requirements. [[1]](diffhunk://#diff-278b414c47d2934820f3d227a5faa32d485d5e46baa854fe8317b38ee9f5609fL444-R470) [[2]](diffhunk://#diff-278b414c47d2934820f3d227a5faa32d485d5e46baa854fe8317b38ee9f5609fL532-R643)

**GitHub Email Handling Improvements:**

* Added logic to fetch and verify the user's primary email from GitHub if the default profile email is missing or a placeholder, ensuring accurate email association during authentication. Also introduced the `GitHubUserEmail` type and a helper method for retrieving emails. [[1]](diffhunk://#diff-25c35c799a1700794d71dc5369f3ab64bf6f2f63693ec819cfa051a24413124fL102-L126) [[2]](diffhunk://#diff-75e9d6182286b76fe1abe44aaea8fbcc71ef79b2a9933c2d06f741838fdf6d0cR24-R30) [[3]](diffhunk://#diff-75e9d6182286b76fe1abe44aaea8fbcc71ef79b2a9933c2d06f741838fdf6d0cR113-R130)

**Frontend Integration:**

* Updated the login form component to use the new `/login` routes for GitHub, Google, and Meta authentication, aligning the frontend with the backend changes.

**Codebase Cleanup:**

* Removed the now-unused `isUserAuthenticated` helper function, as authentication status is checked directly in route handlers.