### PR TITLE
Added option to skip building the apk

### DIFF
--- a/deployment/Dockerfile.mobile
+++ b/deployment/Dockerfile.mobile
@@ -1,6 +1,8 @@
 # Flutter Mobile Build Dockerfile
 FROM ghcr.io/cirruslabs/flutter:3.35.4 AS builder
 
+ARG SKIP_APK_BUILD=false
+
 WORKDIR /app
 
 COPY mobile/ ./
@@ -9,7 +11,13 @@ RUN flutter clean
 
 RUN flutter pub get
 
-RUN flutter build apk --release
+RUN if [ "$SKIP_APK_BUILD" != "true" ]; then \
+        flutter build apk --release; \
+    else \
+        echo "Skipping APK build for development"; \
+        mkdir -p /app/build/app/outputs/flutter-apk/; \
+        touch /app/build/app/outputs/flutter-apk/app-release.apk; \
+    fi
 
 # Create the final stage with just the APK
 FROM alpine:latest AS runner

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -51,6 +51,8 @@ services:
     build:
       context: ..
       dockerfile: deployment/Dockerfile.mobile
+      args:
+        - SKIP_APK_BUILD=${SKIP_APK_BUILD:-false}
     container_name: area_mobile
     volumes:
       - mobile_build:/app/build


### PR DESCRIPTION
This pull request adds support for conditionally skipping the APK build step in the mobile Docker build process, making it easier to speed up development workflows. The main changes introduce a new build argument to control whether the APK is built or a placeholder is created instead.

**Mobile build process improvements:**

* Added an `ARG SKIP_APK_BUILD` to `deployment/Dockerfile.mobile` to allow skipping the APK build step.
* Updated the APK build command in `deployment/Dockerfile.mobile` to conditionally run the build or create a placeholder APK file based on the value of `SKIP_APK_BUILD`.

**Docker Compose integration:**

* Passed the `SKIP_APK_BUILD` argument from `deployment/docker-compose.yml` to the Docker build, enabling easy configuration from the compose file.