### PR TITLE
fix (backend): webhook url

### DIFF
--- a/backend/src/services/services/github/webhookManager.ts
+++ b/backend/src/services/services/github/webhookManager.ts
@@ -206,7 +206,7 @@ export class GitHubWebhookManager {
 
   private generateWebhookUrl(): string {
     const baseUrl = process.env.WEBHOOK_BASE_URL || '';
-    return `${baseUrl}/webhooks/github`;
+    return `${baseUrl}/api/webhooks/github`;
   }
 
   private generateSecret(): string {


### PR DESCRIPTION
This pull request makes a small change to the webhook URL generated by the `GitHubWebhookManager` service. The endpoint has been updated to use `/api/webhooks/github` instead of `/webhooks/github`.