### PR TITLE
backend - services ar communications

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -25,6 +25,8 @@ import webhookRoutes from './src/webhooks';
 import githubRoutes from './src/routes/github/github';
 import googleRoutes from './src/routes/google/google';
 import serviceConfigRoutes from './src/routes/services/configs';
+import servicesRoutes from './src/routes/services';
+import mappingsRoutes from './src/routes/services/mappings';
 
 import { executionService } from './src/services/ExecutionService';
 import { serviceLoader } from './src/services/ServiceLoader';
@@ -136,6 +138,8 @@ setupSignal();
     app.use('/api/github', githubRoutes);
     app.use('/api/google', googleRoutes);
     app.use('/api/services', serviceConfigRoutes);
+    app.use('/api/services', servicesRoutes);
+    app.use('/api/mappings', mappingsRoutes);
     app.use('/api/info', apiRoutes);
     app.use('/about.json', aboutRoutes);
     app.use('/api/webhooks', webhookRoutes);

--- a/backend/src/config/entity/Session.ts
+++ b/backend/src/config/entity/Session.ts
@@ -11,4 +11,7 @@ export class Session extends BaseEntity {
 
   @Column('text')
   json!: string;
+
+  @Column('timestamp', { nullable: true })
+  destroyedAt?: Date;
 }

--- a/backend/src/config/entity/WebhookConfigs.ts
+++ b/backend/src/config/entity/WebhookConfigs.ts
@@ -19,7 +19,7 @@ export class WebhookConfigs extends BaseEntity {
   @Column({ type: 'jsonb' })
   action!: Action;
 
-  @Column({ type: 'jsonb', array: true })
+  @Column({ type: 'jsonb' })
   reactions!: Reaction[];
 
   @Column({ type: 'boolean', default: true })

--- a/backend/src/routes/services/index.ts
+++ b/backend/src/routes/services/index.ts
@@ -1,0 +1,271 @@
+import express, { Request, Response } from 'express';
+import token from '../../middleware/token';
+import { serviceRegistry } from '../../services/ServiceRegistry';
+
+const router = express.Router();
+
+/**
+ * @swagger
+ * /api/services/actions:
+ *   get:
+ *     summary: Get all services that expose actions
+ *     tags:
+ *       - Services
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: List of services with actions
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 services:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: string
+ *                       name:
+ *                         type: string
+ *                       description:
+ *                         type: string
+ *                       version:
+ *                         type: string
+ *                       actions:
+ *                         type: array
+ *                         items:
+ *                           type: object
+ *       500:
+ *         description: Internal server error
+ */
+router.get(
+  '/actions',
+  token,
+  async (req: Request, res: Response): Promise<Response> => {
+    try {
+      const allServices = serviceRegistry.getAllServices();
+      const servicesWithActions = allServices.filter(
+        service => service.actions && service.actions.length > 0
+      );
+
+      return res.status(200).json({
+        services: servicesWithActions.map(service => ({
+          id: service.id,
+          name: service.name,
+          description: service.description,
+          version: service.version,
+          actions: service.actions,
+        })),
+      });
+    } catch (err) {
+      console.error('Error fetching services with actions:', err);
+      return res.status(500).json({ error: 'Internal Server Error' });
+    }
+  }
+);
+
+/**
+ * @swagger
+ * /api/services/reactions:
+ *   get:
+ *     summary: Get all services that expose reactions
+ *     tags:
+ *       - Services
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: List of services with reactions
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 services:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: string
+ *                       name:
+ *                         type: string
+ *                       description:
+ *                         type: string
+ *                       version:
+ *                         type: string
+ *                       reactions:
+ *                         type: array
+ *                         items:
+ *                           type: object
+ *       500:
+ *         description: Internal server error
+ */
+router.get(
+  '/reactions',
+  token,
+  async (req: Request, res: Response): Promise<Response> => {
+    try {
+      const allServices = serviceRegistry.getAllServices();
+      const servicesWithReactions = allServices.filter(
+        service => service.reactions && service.reactions.length > 0
+      );
+
+      return res.status(200).json({
+        services: servicesWithReactions.map(service => ({
+          id: service.id,
+          name: service.name,
+          description: service.description,
+          version: service.version,
+          reactions: service.reactions,
+        })),
+      });
+    } catch (err) {
+      console.error('Error fetching services with reactions:', err);
+      return res.status(500).json({ error: 'Internal Server Error' });
+    }
+  }
+);
+
+/**
+ * @swagger
+ * /api/services/{id}/actions:
+ *   get:
+ *     summary: Get all actions of a specific service
+ *     tags:
+ *       - Services
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Service ID
+ *     responses:
+ *       200:
+ *         description: List of actions for the service
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 service_id:
+ *                   type: string
+ *                 service_name:
+ *                   type: string
+ *                 actions:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *       404:
+ *         description: Service not found
+ *       500:
+ *         description: Internal server error
+ */
+router.get(
+  '/:id/actions',
+  token,
+  async (req: Request, res: Response): Promise<Response> => {
+    try {
+      const { id } = req.params;
+
+      if (!id) {
+        return res.status(400).json({ error: 'Service ID is required' });
+      }
+
+      const service = serviceRegistry.getService(id);
+
+      if (!service) {
+        return res.status(404).json({
+          error: 'Service not found',
+          service_id: id,
+        });
+      }
+
+      return res.status(200).json({
+        service_id: service.id,
+        service_name: service.name,
+        actions: service.actions,
+      });
+    } catch (err) {
+      console.error('Error fetching service actions:', err);
+      return res.status(500).json({ error: 'Internal Server Error' });
+    }
+  }
+);
+
+/**
+ * @swagger
+ * /api/services/{id}/reactions:
+ *   get:
+ *     summary: Get all reactions of a specific service
+ *     tags:
+ *       - Services
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Service ID
+ *     responses:
+ *       200:
+ *         description: List of reactions for the service
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 service_id:
+ *                   type: string
+ *                 service_name:
+ *                   type: string
+ *                 reactions:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *       404:
+ *         description: Service not found
+ *       500:
+ *         description: Internal server error
+ */
+router.get(
+  '/:id/reactions',
+  token,
+  async (req: Request, res: Response): Promise<Response> => {
+    try {
+      const { id } = req.params;
+
+      if (!id) {
+        return res.status(400).json({ error: 'Service ID is required' });
+      }
+
+      const service = serviceRegistry.getService(id);
+
+      if (!service) {
+        return res.status(404).json({
+          error: 'Service not found',
+          service_id: id,
+        });
+      }
+
+      return res.status(200).json({
+        service_id: service.id,
+        service_name: service.name,
+        reactions: service.reactions,
+      });
+    } catch (err) {
+      console.error('Error fetching service reactions:', err);
+      return res.status(500).json({ error: 'Internal Server Error' });
+    }
+  }
+);
+
+export default router;

--- a/backend/src/routes/services/mappings.service.ts
+++ b/backend/src/routes/services/mappings.service.ts
@@ -1,0 +1,196 @@
+import { AppDataSource } from '../../config/db';
+import { WebhookConfigs } from '../../config/entity/WebhookConfigs';
+import { Not } from 'typeorm';
+import type { Action, Reaction } from '../../types/mapping';
+
+export class MappingService {
+  private mappingRepository = AppDataSource.getRepository(WebhookConfigs);
+
+  generateDefaultName(action: Action, reactions: Reaction[]): string {
+    const actionPart = action.type.replace(/\./g, ' ').replace(/_/g, ' ');
+
+    if (reactions.length === 1 && reactions[0]) {
+      const reactionPart = reactions[0].type
+        .replace(/\./g, ' ')
+        .replace(/_/g, ' ');
+      return `${actionPart} → ${reactionPart}`;
+    } else {
+      return `${actionPart} → ${reactions.length} reactions`;
+    }
+  }
+
+  async generateUniqueName(
+    baseName: string,
+    userId: number,
+    excludeId?: number
+  ): Promise<string> {
+    let uniqueName = baseName;
+    let counter = 1;
+
+    while (await this.isNameTaken(uniqueName, userId, excludeId)) {
+      uniqueName = `${baseName} (${counter})`;
+      counter++;
+    }
+
+    return uniqueName;
+  }
+
+  async isNameTaken(
+    name: string,
+    userId: number,
+    excludeId?: number
+  ): Promise<boolean> {
+    if (excludeId) {
+      const existing = await this.mappingRepository.findOne({
+        where: {
+          name,
+          created_by: userId,
+          id: Not(excludeId),
+        },
+      });
+      return !!existing;
+    }
+
+    const existing = await this.mappingRepository.findOne({
+      where: {
+        name,
+        created_by: userId,
+      },
+    });
+
+    return !!existing;
+  }
+
+  async createMapping(data: {
+    name?: string;
+    description?: string;
+    action: Action;
+    reactions: Reaction[];
+    delay?: number;
+    is_active?: boolean;
+    created_by: number;
+  }): Promise<WebhookConfigs> {
+    const {
+      name,
+      description,
+      action,
+      reactions,
+      delay,
+      is_active = true,
+      created_by,
+    } = data;
+
+    let finalName: string;
+    if (name) {
+      finalName = await this.generateUniqueName(name, created_by);
+    } else {
+      const defaultName = this.generateDefaultName(action, reactions);
+      finalName = await this.generateUniqueName(defaultName, created_by);
+    }
+
+    const newMapping = new WebhookConfigs();
+    newMapping.name = finalName;
+    newMapping.description = description || null;
+    newMapping.action = action;
+    newMapping.reactions = reactions;
+    newMapping.is_active = is_active;
+    newMapping.created_by = created_by;
+
+    if (delay !== undefined && delay > 0) {
+      newMapping.action = {
+        ...action,
+        config: {
+          ...action.config,
+          delay: delay,
+        },
+      };
+    }
+
+    return await this.mappingRepository.save(newMapping);
+  }
+
+  async getUserMappings(userId: number): Promise<WebhookConfigs[]> {
+    return await this.mappingRepository.find({
+      where: {
+        created_by: userId,
+      },
+      order: {
+        created_at: 'DESC',
+      },
+    });
+  }
+
+  async getMappingById(
+    id: number,
+    userId: number
+  ): Promise<WebhookConfigs | null> {
+    return await this.mappingRepository.findOne({
+      where: {
+        id,
+        created_by: userId,
+      },
+    });
+  }
+
+  async deleteMapping(id: number, userId: number): Promise<boolean> {
+    const mapping = await this.getMappingById(id, userId);
+    if (!mapping) {
+      return false;
+    }
+
+    await this.mappingRepository.remove(mapping);
+    return true;
+  }
+
+  async updateMapping(
+    id: number,
+    userId: number,
+    updates: {
+      name?: string;
+      description?: string;
+      action?: Action;
+      reactions?: Reaction[];
+      delay?: number;
+      is_active?: boolean;
+    }
+  ): Promise<WebhookConfigs | null> {
+    const mapping = await this.getMappingById(id, userId);
+    if (!mapping) {
+      return null;
+    }
+
+    if (updates.name !== undefined) {
+      mapping.name = await this.generateUniqueName(updates.name, userId, id);
+    }
+
+    if (updates.description !== undefined) {
+      mapping.description = updates.description || null;
+    }
+
+    if (updates.action !== undefined) {
+      mapping.action = updates.action;
+    }
+
+    if (updates.reactions !== undefined) {
+      mapping.reactions = updates.reactions;
+    }
+
+    if (updates.is_active !== undefined) {
+      mapping.is_active = updates.is_active;
+    }
+
+    if (updates.delay !== undefined) {
+      mapping.action = {
+        ...mapping.action,
+        config: {
+          ...mapping.action.config,
+          delay: updates.delay > 0 ? updates.delay : undefined,
+        },
+      };
+    }
+
+    return await this.mappingRepository.save(mapping);
+  }
+}
+
+export const mappingService = new MappingService();

--- a/backend/src/routes/services/mappings.service.ts
+++ b/backend/src/routes/services/mappings.service.ts
@@ -66,7 +66,6 @@ export class MappingService {
     description?: string;
     action: Action;
     reactions: Reaction[];
-    delay?: number;
     is_active?: boolean;
     created_by: number;
   }): Promise<WebhookConfigs> {
@@ -75,7 +74,6 @@ export class MappingService {
       description,
       action,
       reactions,
-      delay,
       is_active = true,
       created_by,
     } = data;
@@ -95,16 +93,6 @@ export class MappingService {
     newMapping.reactions = reactions;
     newMapping.is_active = is_active;
     newMapping.created_by = created_by;
-
-    if (delay !== undefined && delay > 0) {
-      newMapping.action = {
-        ...action,
-        config: {
-          ...action.config,
-          delay: delay,
-        },
-      };
-    }
 
     return await this.mappingRepository.save(newMapping);
   }
@@ -150,7 +138,6 @@ export class MappingService {
       description?: string;
       action?: Action;
       reactions?: Reaction[];
-      delay?: number;
       is_active?: boolean;
     }
   ): Promise<WebhookConfigs | null> {
@@ -177,16 +164,6 @@ export class MappingService {
 
     if (updates.is_active !== undefined) {
       mapping.is_active = updates.is_active;
-    }
-
-    if (updates.delay !== undefined) {
-      mapping.action = {
-        ...mapping.action,
-        config: {
-          ...mapping.action.config,
-          delay: updates.delay > 0 ? updates.delay : undefined,
-        },
-      };
     }
 
     return await this.mappingRepository.save(mapping);

--- a/backend/src/routes/services/mappings.ts
+++ b/backend/src/routes/services/mappings.ts
@@ -64,6 +64,14 @@ function validateMappingRequest(body: unknown): {
           `Reaction ${index + 1}: config is required and must be an object`
         );
       }
+
+      if (reactionObj.delay !== undefined) {
+        if (typeof reactionObj.delay !== 'number' || reactionObj.delay < 0) {
+          errors.push(
+            `Reaction ${index + 1}: delay must be a positive number (seconds)`
+          );
+        }
+      }
     });
   }
 
@@ -162,10 +170,10 @@ function validateActionReactionTypes(
  *                     config:
  *                       type: object
  *                       description: Reaction configuration
- *               delay:
- *                 type: number
- *                 description: Optional delay in seconds before executing reactions
- *                 minimum: 0
+ *                     delay:
+ *                       type: number
+ *                       description: Optional delay in seconds before executing this reaction
+ *                       minimum: 0
  *               is_active:
  *                 type: boolean
  *                 description: Whether the mapping is active
@@ -227,7 +235,6 @@ router.post(
         description,
         action,
         reactions,
-        delay,
         is_active = true,
       } = req.body;
 
@@ -244,7 +251,6 @@ router.post(
         description,
         action,
         reactions,
-        delay,
         is_active,
         created_by: userId,
       });
@@ -256,7 +262,6 @@ router.post(
           description: savedMapping.description,
           action: savedMapping.action,
           reactions: savedMapping.reactions,
-          delay: savedMapping.action.config?.delay || null,
           is_active: savedMapping.is_active,
           created_by: savedMapping.created_by,
           created_at: savedMapping.created_at,
@@ -300,7 +305,6 @@ router.get(
           description: mapping.description,
           action: mapping.action,
           reactions: mapping.reactions,
-          delay: mapping.action.config?.delay || null,
           is_active: mapping.is_active,
           created_by: mapping.created_by,
           created_at: mapping.created_at,
@@ -370,7 +374,6 @@ router.get(
           description: mapping.description,
           action: mapping.action,
           reactions: mapping.reactions,
-          delay: mapping.action.config?.delay || null,
           is_active: mapping.is_active,
           created_by: mapping.created_by,
           created_at: mapping.created_at,

--- a/backend/src/routes/services/mappings.ts
+++ b/backend/src/routes/services/mappings.ts
@@ -6,9 +6,6 @@ import type { Action, Reaction } from '../../types/mapping';
 
 const router = express.Router();
 
-/**
- * Validates a mapping request body
- */
 function validateMappingRequest(body: unknown): {
   isValid: boolean;
   errors: string[];
@@ -81,9 +78,6 @@ function validateMappingRequest(body: unknown): {
   };
 }
 
-/**
- * Validates that action and reaction types exist in the service registry
- */
 function validateActionReactionTypes(
   action: Action,
   reactions: Reaction[]
@@ -93,7 +87,6 @@ function validateActionReactionTypes(
 } {
   const errors: string[] = [];
 
-  // Validate action type exists
   const actionDefinition = serviceRegistry.getActionByType(action.type);
   if (!actionDefinition) {
     errors.push(
@@ -101,7 +94,6 @@ function validateActionReactionTypes(
     );
   }
 
-  // Validate all reaction types exist
   reactions.forEach((reaction, index) => {
     const reactionDefinition = serviceRegistry.getReactionByType(reaction.type);
     if (!reactionDefinition) {

--- a/backend/src/routes/services/mappings.ts
+++ b/backend/src/routes/services/mappings.ts
@@ -1,0 +1,446 @@
+import express, { Request, Response } from 'express';
+import token from '../../middleware/token';
+import { serviceRegistry } from '../../services/ServiceRegistry';
+import { mappingService } from './mappings.service';
+import type { Action, Reaction } from '../../types/mapping';
+
+const router = express.Router();
+
+/**
+ * Validates a mapping request body
+ */
+function validateMappingRequest(body: unknown): {
+  isValid: boolean;
+  errors: string[];
+} {
+  const errors: string[] = [];
+
+  if (!body || typeof body !== 'object') {
+    errors.push('Request body must be an object');
+    return { isValid: false, errors };
+  }
+
+  const bodyObj = body as Record<string, unknown>;
+
+  if (
+    bodyObj.name !== undefined &&
+    (typeof bodyObj.name !== 'string' || bodyObj.name.trim() === '')
+  ) {
+    errors.push('Name must be a non-empty string if provided');
+  }
+
+  if (!bodyObj.action || typeof bodyObj.action !== 'object') {
+    errors.push('Action is required and must be an object');
+  } else {
+    const action = bodyObj.action as Record<string, unknown>;
+    if (!action.type || typeof action.type !== 'string') {
+      errors.push('Action type is required and must be a string');
+    }
+    if (!action.config || typeof action.config !== 'object') {
+      errors.push('Action config is required and must be an object');
+    }
+  }
+
+  if (
+    !bodyObj.reactions ||
+    !Array.isArray(bodyObj.reactions) ||
+    bodyObj.reactions.length === 0
+  ) {
+    errors.push('Reactions is required and must be a non-empty array');
+  } else {
+    bodyObj.reactions.forEach((reaction: unknown, index: number) => {
+      if (!reaction || typeof reaction !== 'object') {
+        errors.push(`Reaction ${index + 1}: must be an object`);
+        return;
+      }
+      const reactionObj = reaction as Record<string, unknown>;
+      if (!reactionObj.type || typeof reactionObj.type !== 'string') {
+        errors.push(
+          `Reaction ${index + 1}: type is required and must be a string`
+        );
+      }
+      if (!reactionObj.config || typeof reactionObj.config !== 'object') {
+        errors.push(
+          `Reaction ${index + 1}: config is required and must be an object`
+        );
+      }
+    });
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+  };
+}
+
+/**
+ * Validates that action and reaction types exist in the service registry
+ */
+function validateActionReactionTypes(
+  action: Action,
+  reactions: Reaction[]
+): {
+  isValid: boolean;
+  errors: string[];
+} {
+  const errors: string[] = [];
+
+  // Validate action type exists
+  const actionDefinition = serviceRegistry.getActionByType(action.type);
+  if (!actionDefinition) {
+    errors.push(
+      `Action type '${action.type}' not found in any registered service`
+    );
+  }
+
+  // Validate all reaction types exist
+  reactions.forEach((reaction, index) => {
+    const reactionDefinition = serviceRegistry.getReactionByType(reaction.type);
+    if (!reactionDefinition) {
+      errors.push(
+        `Reaction ${index + 1} type '${reaction.type}' not found in any registered service`
+      );
+    }
+  });
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+  };
+}
+
+/**
+ * @swagger
+ * /api/mappings:
+ *   post:
+ *     summary: Create a mapping between an action and one or more reactions
+ *     tags:
+ *       - Mappings
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - name
+ *               - action
+ *               - reactions
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 description: Human-readable name for the mapping
+ *               description:
+ *                 type: string
+ *                 description: Optional description of the mapping
+ *               action:
+ *                 type: object
+ *                 required:
+ *                   - type
+ *                   - config
+ *                 properties:
+ *                   type:
+ *                     type: string
+ *                     description: Action type in format "service.action"
+ *                   config:
+ *                     type: object
+ *                     description: Action configuration
+ *               reactions:
+ *                 type: array
+ *                 minItems: 1
+ *                 items:
+ *                   type: object
+ *                   required:
+ *                     - type
+ *                     - config
+ *                   properties:
+ *                     type:
+ *                       type: string
+ *                       description: Reaction type in format "service.reaction"
+ *                     config:
+ *                       type: object
+ *                       description: Reaction configuration
+ *               delay:
+ *                 type: number
+ *                 description: Optional delay in seconds before executing reactions
+ *                 minimum: 0
+ *               is_active:
+ *                 type: boolean
+ *                 description: Whether the mapping is active
+ *                 default: true
+ *     responses:
+ *       201:
+ *         description: Mapping created successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 mapping:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: number
+ *                     name:
+ *                       type: string
+ *                     description:
+ *                       type: string
+ *                     action:
+ *                       type: object
+ *                     reactions:
+ *                       type: array
+ *                     delay:
+ *                       type: number
+ *                     is_active:
+ *                       type: boolean
+ *                     created_by:
+ *                       type: number
+ *                     created_at:
+ *                       type: string
+ *                       format: date-time
+ *       400:
+ *         description: Invalid request data
+ *       404:
+ *         description: Action or reaction type not found
+ *       500:
+ *         description: Internal server error
+ */
+router.post(
+  '/',
+  token,
+  async (req: Request, res: Response): Promise<Response> => {
+    try {
+      const userId = (req.auth as { id: number }).id;
+
+      const validation = validateMappingRequest(req.body);
+      if (!validation.isValid) {
+        return res.status(400).json({
+          error: 'Invalid request data',
+          details: validation.errors,
+        });
+      }
+
+      const {
+        name,
+        description,
+        action,
+        reactions,
+        delay,
+        is_active = true,
+      } = req.body;
+
+      const typeValidation = validateActionReactionTypes(action, reactions);
+      if (!typeValidation.isValid) {
+        return res.status(404).json({
+          error: 'Invalid action or reaction types',
+          details: typeValidation.errors,
+        });
+      }
+
+      const savedMapping = await mappingService.createMapping({
+        name: name || undefined,
+        description,
+        action,
+        reactions,
+        delay,
+        is_active,
+        created_by: userId,
+      });
+
+      return res.status(201).json({
+        mapping: {
+          id: savedMapping.id,
+          name: savedMapping.name,
+          description: savedMapping.description,
+          action: savedMapping.action,
+          reactions: savedMapping.reactions,
+          delay: savedMapping.action.config?.delay || null,
+          is_active: savedMapping.is_active,
+          created_by: savedMapping.created_by,
+          created_at: savedMapping.created_at,
+          updated_at: savedMapping.updated_at,
+        },
+      });
+    } catch (err) {
+      console.error('Error creating mapping:', err);
+      return res.status(500).json({ error: 'Internal Server Error' });
+    }
+  }
+);
+
+/**
+ * @swagger
+ * /api/mappings:
+ *   get:
+ *     summary: Get all mappings for the authenticated user
+ *     tags:
+ *       - Mappings
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: List of user mappings
+ *       500:
+ *         description: Internal server error
+ */
+router.get(
+  '/',
+  token,
+  async (req: Request, res: Response): Promise<Response> => {
+    try {
+      const userId = (req.auth as { id: number }).id;
+      const mappings = await mappingService.getUserMappings(userId);
+
+      return res.status(200).json({
+        mappings: mappings.map(mapping => ({
+          id: mapping.id,
+          name: mapping.name,
+          description: mapping.description,
+          action: mapping.action,
+          reactions: mapping.reactions,
+          delay: mapping.action.config?.delay || null,
+          is_active: mapping.is_active,
+          created_by: mapping.created_by,
+          created_at: mapping.created_at,
+          updated_at: mapping.updated_at,
+        })),
+      });
+    } catch (err) {
+      console.error('Error fetching mappings:', err);
+      return res.status(500).json({ error: 'Internal Server Error' });
+    }
+  }
+);
+
+/**
+ * @swagger
+ * /api/mappings/{id}:
+ *   get:
+ *     summary: Get a specific mapping by ID
+ *     tags:
+ *       - Mappings
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Mapping details
+ *       404:
+ *         description: Mapping not found
+ *       500:
+ *         description: Internal server error
+ */
+router.get(
+  '/:id',
+  token,
+  async (req: Request, res: Response): Promise<Response> => {
+    try {
+      const userId = (req.auth as { id: number }).id;
+      const { id } = req.params;
+
+      if (!id) {
+        return res.status(400).json({ error: 'Mapping ID is required' });
+      }
+
+      const mappingId = parseInt(id);
+
+      if (isNaN(mappingId)) {
+        return res.status(400).json({ error: 'Invalid mapping ID' });
+      }
+
+      const mapping = await mappingService.getMappingById(mappingId, userId);
+
+      if (!mapping) {
+        return res.status(404).json({
+          error: 'Mapping not found',
+        });
+      }
+
+      return res.status(200).json({
+        mapping: {
+          id: mapping.id,
+          name: mapping.name,
+          description: mapping.description,
+          action: mapping.action,
+          reactions: mapping.reactions,
+          delay: mapping.action.config?.delay || null,
+          is_active: mapping.is_active,
+          created_by: mapping.created_by,
+          created_at: mapping.created_at,
+          updated_at: mapping.updated_at,
+        },
+      });
+    } catch (err) {
+      console.error('Error fetching mapping:', err);
+      return res.status(500).json({ error: 'Internal Server Error' });
+    }
+  }
+);
+
+/**
+ * @swagger
+ * /api/mappings/{id}:
+ *   delete:
+ *     summary: Delete a mapping
+ *     tags:
+ *       - Mappings
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Mapping deleted successfully
+ *       404:
+ *         description: Mapping not found
+ *       500:
+ *         description: Internal server error
+ */
+router.delete(
+  '/:id',
+  token,
+  async (req: Request, res: Response): Promise<Response> => {
+    try {
+      const userId = (req.auth as { id: number }).id;
+      const { id } = req.params;
+
+      if (!id) {
+        return res.status(400).json({ error: 'Mapping ID is required' });
+      }
+
+      const mappingId = parseInt(id);
+
+      if (isNaN(mappingId)) {
+        return res.status(400).json({ error: 'Invalid mapping ID' });
+      }
+
+      const deleted = await mappingService.deleteMapping(mappingId, userId);
+
+      if (!deleted) {
+        return res.status(404).json({
+          error: 'Mapping not found',
+        });
+      }
+
+      return res.status(200).json({
+        message: 'Mapping deleted successfully',
+      });
+    } catch (err) {
+      console.error('Error deleting mapping:', err);
+      return res.status(500).json({ error: 'Internal Server Error' });
+    }
+  }
+);
+
+export default router;

--- a/backend/src/types/mapping.ts
+++ b/backend/src/types/mapping.ts
@@ -9,6 +9,7 @@ export interface Action {
 export interface Reaction {
   type: string;
   config: Record<string, unknown>;
+  delay?: number;
 }
 
 export interface ActionReactionMapping {


### PR DESCRIPTION
This pull request introduces several new features and improvements to the backend service routing, entity models, and the execution logic for delayed reactions. The main focus is on expanding the API to provide more granular service information, supporting delayed reaction execution, and improving mapping management.

### API and Routing Enhancements

* Added new routes in `backend/index.ts` and implemented `backend/src/routes/services/index.ts` to allow querying services for their actions and reactions, as well as retrieving actions/reactions for a specific service. These endpoints are documented with Swagger and require authentication. [[1]](diffhunk://#diff-bdce6c197e915a5e5fd34714b3512bf28eb09351d85d30346eb73e3823739de5R28-R29) [[2]](diffhunk://#diff-bdce6c197e915a5e5fd34714b3512bf28eb09351d85d30346eb73e3823739de5R141-R142) [[3]](diffhunk://#diff-c854ecfb8a1ce95e3689a144016021605424309ba28da9d02f010623dbbc82e7R1-R271)

### Mapping Management

* Introduced `backend/src/routes/services/mappings.service.ts`, providing a `MappingService` class for creating, updating, deleting, and querying action-reaction mappings, including logic for generating unique and default mapping names.
* Updated the `WebhookConfigs` entity so that the `reactions` field is now a single JSON array instead of an array of JSON objects, simplifying the data model.

### Delayed Reaction Execution

* Extended the `Reaction` type to include an optional `delay` property, enabling scheduling of reactions to run after a specified delay.
* Enhanced the `ExecutionService` to handle delayed reactions: reactions with a delay are scheduled and tracked, can be cancelled, and are properly cleaned up when the service stops. Immediate reactions are executed as before. [[1]](diffhunk://#diff-6e4410583ee595c92852653fe5ef54f4549e7db25461dae7b90aa84629a29634R16) [[2]](diffhunk://#diff-6e4410583ee595c92852653fe5ef54f4549e7db25461dae7b90aa84629a29634R48-R75) [[3]](diffhunk://#diff-6e4410583ee595c92852653fe5ef54f4549e7db25461dae7b90aa84629a29634L167-R228)

### Entity Model Update

* Added a `destroyedAt` timestamp to the `Session` entity to support tracking of session destruction.