### PR TITLE
fix (backend): swagger docs

### DIFF
--- a/backend/src/routes/services/mappings.ts
+++ b/backend/src/routes/services/mappings.ts
@@ -202,8 +202,34 @@ function validateActionReactionTypes(
  *                       format: date-time
  *       400:
  *         description: Invalid request data
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "Invalid request data"
+ *                 details:
+ *                   type: array
+ *                   items:
+ *                     type: string
+ *                   description: List of validation errors
  *       404:
  *         description: Action or reaction type not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "Invalid action or reaction types"
+ *                 details:
+ *                   type: array
+ *                   items:
+ *                     type: string
+ *                   description: List of invalid types
  *       500:
  *         description: Internal server error
  */
@@ -279,6 +305,64 @@ router.post(
  *     responses:
  *       200:
  *         description: List of user mappings
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 mappings:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: integer
+ *                         description: Unique identifier for the mapping
+ *                       name:
+ *                         type: string
+ *                         description: Human-readable name for the mapping
+ *                       description:
+ *                         type: string
+ *                         description: Optional description of the mapping
+ *                       action:
+ *                         type: object
+ *                         description: Action configuration
+ *                         properties:
+ *                           type:
+ *                             type: string
+ *                             description: Action type in format "service.action"
+ *                           config:
+ *                             type: object
+ *                             description: Action configuration parameters
+ *                       reactions:
+ *                         type: array
+ *                         items:
+ *                           type: object
+ *                           properties:
+ *                             type:
+ *                               type: string
+ *                               description: Reaction type in format "service.reaction"
+ *                             config:
+ *                               type: object
+ *                               description: Reaction configuration parameters
+ *                             delay:
+ *                               type: number
+ *                               description: Optional delay in seconds before executing this reaction
+ *                               minimum: 0
+ *                       is_active:
+ *                         type: boolean
+ *                         description: Whether the mapping is currently active
+ *                       created_by:
+ *                         type: integer
+ *                         description: ID of the user who created the mapping
+ *                       created_at:
+ *                         type: string
+ *                         format: date-time
+ *                         description: Timestamp when the mapping was created
+ *                       updated_at:
+ *                         type: string
+ *                         format: date-time
+ *                         description: Timestamp when the mapping was last updated
  *       500:
  *         description: Internal server error
  */
@@ -325,11 +409,86 @@ router.get(
  *         required: true
  *         schema:
  *           type: integer
+ *         description: Unique identifier of the mapping
  *     responses:
  *       200:
  *         description: Mapping details
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 mapping:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: integer
+ *                       description: Unique identifier for the mapping
+ *                     name:
+ *                       type: string
+ *                       description: Human-readable name for the mapping
+ *                     description:
+ *                       type: string
+ *                       description: Optional description of the mapping
+ *                     action:
+ *                       type: object
+ *                       description: Action configuration
+ *                       properties:
+ *                         type:
+ *                           type: string
+ *                           description: Action type in format "service.action"
+ *                         config:
+ *                           type: object
+ *                           description: Action configuration parameters
+ *                     reactions:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           type:
+ *                             type: string
+ *                             description: Reaction type in format "service.reaction"
+ *                           config:
+ *                             type: object
+ *                             description: Reaction configuration parameters
+ *                           delay:
+ *                             type: number
+ *                             description: Optional delay in seconds before executing this reaction
+ *                             minimum: 0
+ *                     is_active:
+ *                       type: boolean
+ *                       description: Whether the mapping is currently active
+ *                     created_by:
+ *                       type: integer
+ *                       description: ID of the user who created the mapping
+ *                     created_at:
+ *                       type: string
+ *                       format: date-time
+ *                       description: Timestamp when the mapping was created
+ *                     updated_at:
+ *                       type: string
+ *                       format: date-time
+ *                       description: Timestamp when the mapping was last updated
+ *       400:
+ *         description: Invalid mapping ID
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "Invalid mapping ID"
  *       404:
  *         description: Mapping not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "Mapping not found"
  *       500:
  *         description: Internal server error
  */
@@ -394,11 +553,38 @@ router.get(
  *         required: true
  *         schema:
  *           type: integer
+ *         description: Unique identifier of the mapping to delete
  *     responses:
  *       200:
  *         description: Mapping deleted successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "Mapping deleted successfully"
+ *       400:
+ *         description: Invalid mapping ID
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "Invalid mapping ID"
  *       404:
  *         description: Mapping not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "Mapping not found"
  *       500:
  *         description: Internal server error
  */


### PR DESCRIPTION
This pull request enhances the OpenAPI documentation for the service mappings API in `backend/src/routes/services/mappings.ts`. The main improvements are the addition of detailed response schemas for the endpoints, including success and error cases, which will help consumers of the API better understand the structure and possible responses.

**OpenAPI Documentation Improvements:**

* Added detailed response schemas for validation errors and not found errors in the `validateActionReactionTypes` endpoint, specifying the structure for error messages and lists of validation issues.

* Documented the structure of the response for the `POST /mappings` endpoint, including all mapping properties such as `id`, `name`, `description`, `action`, `reactions`, `is_active`, `created_by`, and timestamps.

* Expanded the response documentation for the `GET /mappings/:id` endpoint to include a comprehensive schema for mapping details, as well as error responses for invalid IDs and not found cases.

* Added response schemas for the `DELETE /mappings/:id` endpoint, detailing both successful deletion messages and error cases for invalid IDs and not found errors.