### PR TITLE
fix (backend): swagger docs

### DIFF
--- a/backend/src/routes/services/configs.ts
+++ b/backend/src/routes/services/configs.ts
@@ -17,6 +17,37 @@ const userServiceConfigService = new UserServiceConfigService();
  *     responses:
  *       200:
  *         description: List of user's service configurations
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 configs:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: integer
+ *                         description: Unique identifier for the configuration
+ *                       service:
+ *                         type: string
+ *                         description: Service identifier
+ *                       settings:
+ *                         type: object
+ *                         description: Service-specific configuration settings
+ *                         additionalProperties: true
+ *                       is_active:
+ *                         type: boolean
+ *                         description: Whether this configuration is active
+ *                       created_at:
+ *                         type: string
+ *                         format: date-time
+ *                         description: Timestamp when the configuration was created
+ *                       updated_at:
+ *                         type: string
+ *                         format: date-time
+ *                         description: Timestamp when the configuration was last updated
  *       500:
  *         description: Internal server error
  */
@@ -64,6 +95,35 @@ router.get(
  *     responses:
  *       200:
  *         description: Service configuration details
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 config:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: integer
+ *                       description: Unique identifier for the configuration
+ *                     service:
+ *                       type: string
+ *                       description: Service identifier
+ *                     settings:
+ *                       type: object
+ *                       description: Service-specific configuration settings
+ *                       additionalProperties: true
+ *                     is_active:
+ *                       type: boolean
+ *                       description: Whether this configuration is active
+ *                     created_at:
+ *                       type: string
+ *                       format: date-time
+ *                       description: Timestamp when the configuration was created
+ *                     updated_at:
+ *                       type: string
+ *                       format: date-time
+ *                       description: Timestamp when the configuration was last updated
  *       404:
  *         description: Service configuration not found
  *       500:
@@ -130,13 +190,51 @@ router.get(
  *             properties:
  *               service:
  *                 type: string
+ *                 description: Service identifier (must match a registered service)
+ *                 example: "github"
  *               credentials:
  *                 type: object
+ *                 description: Service-specific authentication credentials (API keys, tokens, etc.)
+ *                 additionalProperties:
+ *                   type: string
+ *                 example: {"token": "ghp_...", "username": "myuser"}
  *               settings:
  *                 type: object
+ *                 description: Service-specific configuration settings
+ *                 additionalProperties: true
+ *                 example: {"default_repository": "my-repo", "webhook_url": "https://..."}
  *     responses:
  *       201:
  *         description: Service configuration created/updated
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 config:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: integer
+ *                       description: Unique identifier for the configuration
+ *                     service:
+ *                       type: string
+ *                       description: Service identifier
+ *                     settings:
+ *                       type: object
+ *                       description: Service-specific configuration settings
+ *                       additionalProperties: true
+ *                     is_active:
+ *                       type: boolean
+ *                       description: Whether this configuration is active
+ *                     created_at:
+ *                       type: string
+ *                       format: date-time
+ *                       description: Timestamp when the configuration was created
+ *                     updated_at:
+ *                       type: string
+ *                       format: date-time
+ *                       description: Timestamp when the configuration was last updated
  *       400:
  *         description: Invalid request data
  *       500:
@@ -205,13 +303,51 @@ router.post(
  *             properties:
  *               credentials:
  *                 type: object
+ *                 description: Service-specific authentication credentials (API keys, tokens, etc.)
+ *                 additionalProperties:
+ *                   type: string
+ *                 example: {"token": "ghp_...", "username": "myuser"}
  *               settings:
  *                 type: object
+ *                 description: Service-specific configuration settings
+ *                 additionalProperties: true
+ *                 example: {"default_repository": "my-repo", "webhook_url": "https://..."}
  *               is_active:
  *                 type: boolean
+ *                 description: Whether this service configuration is active
+ *                 example: true
  *     responses:
  *       200:
  *         description: Service configuration updated
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 config:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: integer
+ *                       description: Unique identifier for the configuration
+ *                     service:
+ *                       type: string
+ *                       description: Service identifier
+ *                     settings:
+ *                       type: object
+ *                       description: Service-specific configuration settings
+ *                       additionalProperties: true
+ *                     is_active:
+ *                       type: boolean
+ *                       description: Whether this configuration is active
+ *                     created_at:
+ *                       type: string
+ *                       format: date-time
+ *                       description: Timestamp when the configuration was created
+ *                     updated_at:
+ *                       type: string
+ *                       format: date-time
+ *                       description: Timestamp when the configuration was last updated
  *       404:
  *         description: Service configuration not found
  *       500:

--- a/backend/src/routes/services/index.ts
+++ b/backend/src/routes/services/index.ts
@@ -28,16 +28,117 @@ const router = express.Router();
  *                     properties:
  *                       id:
  *                         type: string
+ *                         description: Unique identifier for the service
  *                       name:
  *                         type: string
+ *                         description: Human-readable name of the service
  *                       description:
  *                         type: string
+ *                         description: Description of the service
  *                       version:
  *                         type: string
+ *                         description: Version of the service
  *                       actions:
  *                         type: array
+ *                         description: List of actions provided by this service
  *                         items:
  *                           type: object
+ *                           properties:
+ *                             id:
+ *                               type: string
+ *                               description: Unique identifier for the action (format: service.action)
+ *                             name:
+ *                               type: string
+ *                               description: Human-readable name of the action
+ *                             description:
+ *                               type: string
+ *                               description: Description of what the action does
+ *                             configSchema:
+ *                               type: object
+ *                               description: Schema defining the configuration fields required for this action
+ *                               properties:
+ *                                 name:
+ *                                   type: string
+ *                                   description: Name of the configuration schema
+ *                                 description:
+ *                                   type: string
+ *                                   description: Description of the configuration schema
+ *                                 fields:
+ *                                   type: array
+ *                                   description: List of configuration fields
+ *                                   items:
+ *                                     type: object
+ *                                     properties:
+ *                                       name:
+ *                                         type: string
+ *                                         description: Field name
+ *                                       type:
+ *                                         type: string
+ *                                         enum: [text, email, textarea, select, checkbox, number]
+ *                                         description: Type of the field
+ *                                       label:
+ *                                         type: string
+ *                                         description: Human-readable label for the field
+ *                                       required:
+ *                                         type: boolean
+ *                                         description: Whether this field is required
+ *                                       placeholder:
+ *                                         type: string
+ *                                         description: Placeholder text for the field
+ *                                       options:
+ *                                         type: array
+ *                                         description: Available options for select fields
+ *                                         items:
+ *                                           type: object
+ *                                           properties:
+ *                                             value:
+ *                                               type: string
+ *                                               description: Option value
+ *                                             label:
+ *                                               type: string
+ *                                               description: Option label
+ *                                       default:
+ *                                         type: string
+ *                                         description: Default value for the field
+ *                             inputSchema:
+ *                               type: object
+ *                               description: Schema defining the input data structure for action execution
+ *                               properties:
+ *                                 type:
+ *                                   type: string
+ *                                   enum: [object]
+ *                                 properties:
+ *                                   type: object
+ *                                   description: Input properties schema
+ *                                 required:
+ *                                   type: array
+ *                                   description: List of required input properties
+ *                                   items:
+ *                                     type: string
+ *                             metadata:
+ *                               type: object
+ *                               description: Additional metadata for the action
+ *                               properties:
+ *                                 category:
+ *                                   type: string
+ *                                   description: Category this action belongs to
+ *                                 tags:
+ *                                   type: array
+ *                                   description: Tags associated with this action
+ *                                   items:
+ *                                     type: string
+ *                                 icon:
+ *                                   type: string
+ *                                   description: Icon identifier for UI display
+ *                                 color:
+ *                                   type: string
+ *                                   description: Color identifier for UI display
+ *                                 requiresAuth:
+ *                                   type: boolean
+ *                                   description: Whether this action requires authentication
+ *                                 webhookPattern:
+ *                                   type: string
+ *                                   description: Webhook pattern for triggering this action
  *       500:
  *         description: Internal server error
  */
@@ -91,16 +192,117 @@ router.get(
  *                     properties:
  *                       id:
  *                         type: string
+ *                         description: Unique identifier for the service
  *                       name:
  *                         type: string
+ *                         description: Human-readable name of the service
  *                       description:
  *                         type: string
+ *                         description: Description of the service
  *                       version:
  *                         type: string
+ *                         description: Version of the service
  *                       reactions:
  *                         type: array
+ *                         description: List of reactions provided by this service
  *                         items:
  *                           type: object
+ *                           properties:
+ *                             id:
+ *                               type: string
+ *                               description: Unique identifier for the reaction (format: service.reaction)
+ *                             name:
+ *                               type: string
+ *                               description: Human-readable name of the reaction
+ *                             description:
+ *                               type: string
+ *                               description: Description of what the reaction does
+ *                             configSchema:
+ *                               type: object
+ *                               description: Schema defining the configuration fields required for this reaction
+ *                               properties:
+ *                                 name:
+ *                                   type: string
+ *                                   description: Name of the configuration schema
+ *                                 description:
+ *                                   type: string
+ *                                   description: Description of the configuration schema
+ *                                 fields:
+ *                                   type: array
+ *                                   description: List of configuration fields
+ *                                   items:
+ *                                     type: object
+ *                                     properties:
+ *                                       name:
+ *                                         type: string
+ *                                         description: Field name
+ *                                       type:
+ *                                         type: string
+ *                                         enum: [text, email, textarea, select, checkbox, number]
+ *                                         description: Type of the field
+ *                                       label:
+ *                                         type: string
+ *                                         description: Human-readable label for the field
+ *                                       required:
+ *                                         type: boolean
+ *                                         description: Whether this field is required
+ *                                       placeholder:
+ *                                         type: string
+ *                                         description: Placeholder text for the field
+ *                                       options:
+ *                                         type: array
+ *                                         description: Available options for select fields
+ *                                         items:
+ *                                           type: object
+ *                                           properties:
+ *                                             value:
+ *                                               type: string
+ *                                               description: Option value
+ *                                             label:
+ *                                               type: string
+ *                                               description: Option label
+ *                                       default:
+ *                                         type: string
+ *                                         description: Default value for the field
+ *                             outputSchema:
+ *                               type: object
+ *                               description: Schema defining the output data structure for reaction execution
+ *                               properties:
+ *                                 type:
+ *                                   type: string
+ *                                   enum: [object]
+ *                                 properties:
+ *                                   type: object
+ *                                   description: Output properties schema
+ *                                 required:
+ *                                   type: array
+ *                                   description: List of required output properties
+ *                                   items:
+ *                                     type: string
+ *                             metadata:
+ *                               type: object
+ *                               description: Additional metadata for the reaction
+ *                               properties:
+ *                                 category:
+ *                                   type: string
+ *                                   description: Category this reaction belongs to
+ *                                 tags:
+ *                                   type: array
+ *                                   description: Tags associated with this reaction
+ *                                   items:
+ *                                     type: string
+ *                                 icon:
+ *                                   type: string
+ *                                   description: Icon identifier for UI display
+ *                                 color:
+ *                                   type: string
+ *                                   description: Color identifier for UI display
+ *                                 requiresAuth:
+ *                                   type: boolean
+ *                                   description: Whether this reaction requires authentication
+ *                                 estimatedDuration:
+ *                                   type: number
+ *                                   description: Estimated execution duration in seconds
  *       500:
  *         description: Internal server error
  */
@@ -156,14 +358,134 @@ router.get(
  *               properties:
  *                 service_id:
  *                   type: string
+ *                   description: Unique identifier of the service
  *                 service_name:
  *                   type: string
+ *                   description: Human-readable name of the service
  *                 actions:
  *                   type: array
+ *                   description: List of actions provided by this service
  *                   items:
  *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: string
+ *                         description: Unique identifier for the action (format: service.action)
+ *                       name:
+ *                         type: string
+ *                         description: Human-readable name of the action
+ *                       description:
+ *                         type: string
+ *                         description: Description of what the action does
+ *                       configSchema:
+ *                         type: object
+ *                         description: Schema defining the configuration fields required for this action
+ *                         properties:
+ *                           name:
+ *                             type: string
+ *                             description: Name of the configuration schema
+ *                           description:
+ *                             type: string
+ *                             description: Description of the configuration schema
+ *                           fields:
+ *                             type: array
+ *                             description: List of configuration fields
+ *                             items:
+ *                               type: object
+ *                               properties:
+ *                                 name:
+ *                                   type: string
+ *                                   description: Field name
+ *                                 type:
+ *                                   type: string
+ *                                   enum: [text, email, textarea, select, checkbox, number]
+ *                                   description: Type of the field
+ *                                 label:
+ *                                   type: string
+ *                                   description: Human-readable label for the field
+ *                                 required:
+ *                                   type: boolean
+ *                                   description: Whether this field is required
+ *                                 placeholder:
+ *                                   type: string
+ *                                   description: Placeholder text for the field
+ *                                 options:
+ *                                   type: array
+ *                                   description: Available options for select fields
+ *                                   items:
+ *                                     type: object
+ *                                     properties:
+ *                                       value:
+ *                                         type: string
+ *                                         description: Option value
+ *                                       label:
+ *                                         type: string
+ *                                         description: Option label
+ *                                 default:
+ *                                   type: string
+ *                                   description: Default value for the field
+ *                       inputSchema:
+ *                         type: object
+ *                         description: Schema defining the input data structure for action execution
+ *                         properties:
+ *                           type:
+ *                             type: string
+ *                             enum: [object]
+ *                           properties:
+ *                             type: object
+ *                             description: Input properties schema
+ *                           required:
+ *                             type: array
+ *                             description: List of required input properties
+ *                             items:
+ *                               type: string
+ *                       metadata:
+ *                         type: object
+ *                         description: Additional metadata for the action
+ *                         properties:
+ *                           category:
+ *                             type: string
+ *                             description: Category this action belongs to
+ *                           tags:
+ *                             type: array
+ *                             description: Tags associated with this action
+ *                             items:
+ *                               type: string
+ *                           icon:
+ *                             type: string
+ *                             description: Icon identifier for UI display
+ *                           color:
+ *                             type: string
+ *                             description: Color identifier for UI display
+ *                           requiresAuth:
+ *                             type: boolean
+ *                             description: Whether this action requires authentication
+ *                           webhookPattern:
+ *                             type: string
+ *                             description: Webhook pattern for triggering this action
+ *       400:
+ *         description: Bad request - missing service ID
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "Service ID is required"
  *       404:
  *         description: Service not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "Service not found"
+ *                 service_id:
+ *                   type: string
+ *                   description: The requested service ID
  *       500:
  *         description: Internal server error
  */
@@ -225,14 +547,134 @@ router.get(
  *               properties:
  *                 service_id:
  *                   type: string
+ *                   description: Unique identifier of the service
  *                 service_name:
  *                   type: string
+ *                   description: Human-readable name of the service
  *                 reactions:
  *                   type: array
+ *                   description: List of reactions provided by this service
  *                   items:
  *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: string
+ *                         description: Unique identifier for the reaction (format: service.reaction)
+ *                       name:
+ *                         type: string
+ *                         description: Human-readable name of the reaction
+ *                       description:
+ *                         type: string
+ *                         description: Description of what the reaction does
+ *                       configSchema:
+ *                         type: object
+ *                         description: Schema defining the configuration fields required for this reaction
+ *                         properties:
+ *                           name:
+ *                             type: string
+ *                             description: Name of the configuration schema
+ *                           description:
+ *                             type: string
+ *                             description: Description of the configuration schema
+ *                           fields:
+ *                             type: array
+ *                             description: List of configuration fields
+ *                             items:
+ *                               type: object
+ *                               properties:
+ *                                 name:
+ *                                   type: string
+ *                                   description: Field name
+ *                                 type:
+ *                                   type: string
+ *                                   enum: [text, email, textarea, select, checkbox, number]
+ *                                   description: Type of the field
+ *                                 label:
+ *                                   type: string
+ *                                   description: Human-readable label for the field
+ *                                 required:
+ *                                   type: boolean
+ *                                   description: Whether this field is required
+ *                                 placeholder:
+ *                                   type: string
+ *                                   description: Placeholder text for the field
+ *                                 options:
+ *                                   type: array
+ *                                   description: Available options for select fields
+ *                                   items:
+ *                                     type: object
+ *                                     properties:
+ *                                       value:
+ *                                         type: string
+ *                                         description: Option value
+ *                                       label:
+ *                                         type: string
+ *                                         description: Option label
+ *                                 default:
+ *                                   type: string
+ *                                   description: Default value for the field
+ *                       outputSchema:
+ *                         type: object
+ *                         description: Schema defining the output data structure for reaction execution
+ *                         properties:
+ *                           type:
+ *                             type: string
+ *                             enum: [object]
+ *                           properties:
+ *                             type: object
+ *                             description: Output properties schema
+ *                           required:
+ *                             type: array
+ *                             description: List of required output properties
+ *                             items:
+ *                               type: string
+ *                       metadata:
+ *                         type: object
+ *                         description: Additional metadata for the reaction
+ *                         properties:
+ *                           category:
+ *                             type: string
+ *                             description: Category this reaction belongs to
+ *                           tags:
+ *                             type: array
+ *                             description: Tags associated with this reaction
+ *                             items:
+ *                               type: string
+ *                           icon:
+ *                             type: string
+ *                             description: Icon identifier for UI display
+ *                           color:
+ *                             type: string
+ *                             description: Color identifier for UI display
+ *                           requiresAuth:
+ *                             type: boolean
+ *                             description: Whether this reaction requires authentication
+ *                           estimatedDuration:
+ *                             type: number
+ *                             description: Estimated execution duration in seconds
+ *       400:
+ *         description: Bad request - missing service ID
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "Service ID is required"
  *       404:
  *         description: Service not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "Service not found"
+ *                 service_id:
+ *                   type: string
+ *                   description: The requested service ID
  *       500:
  *         description: Internal server error
  */

--- a/backend/src/routes/services/mappings.ts
+++ b/backend/src/routes/services/mappings.ts
@@ -143,10 +143,12 @@ function validateActionReactionTypes(
  *                 properties:
  *                   type:
  *                     type: string
- *                     description: Action type in format "service.action"
+ *                     description: Action type in format "service.action" (must exist in a registered service)
+ *                     example: "github.new_issue"
  *                   config:
  *                     type: object
- *                     description: Action configuration
+ *                     description: Action configuration parameters as defined by the action's configSchema from the service registry
+ *                     example: {"repository": "my-repo", "token": "ghp_..."}
  *               reactions:
  *                 type: array
  *                 minItems: 1
@@ -158,10 +160,12 @@ function validateActionReactionTypes(
  *                   properties:
  *                     type:
  *                       type: string
- *                       description: Reaction type in format "service.reaction"
+ *                       description: Reaction type in format "service.reaction" (must exist in a registered service)
+ *                       example: "discord.send_message"
  *                     config:
  *                       type: object
- *                       description: Reaction configuration
+ *                       description: Reaction configuration parameters as defined by the reaction's configSchema from the service registry
+ *                       example: {"channel_id": "123456789", "message": "Hello World!"}
  *                     delay:
  *                       type: number
  *                       description: Optional delay in seconds before executing this reaction
@@ -189,8 +193,17 @@ function validateActionReactionTypes(
  *                       type: string
  *                     action:
  *                       type: object
+ *                       description: The configured action
+ *                       properties:
+ *                         type:
+ *                           type: string
+ *                           description: Action type identifier
+ *                         config:
+ *                           type: object
+ *                           description: Action configuration parameters
  *                     reactions:
  *                       type: array
+ *                       description: List of configured reactions
  *                     delay:
  *                       type: number
  *                     is_active:
@@ -442,8 +455,19 @@ router.get(
  *                           description: Action configuration parameters
  *                     reactions:
  *                       type: array
+ *                       description: List of configured reactions
  *                       items:
  *                         type: object
+ *                         properties:
+ *                           type:
+ *                             type: string
+ *                             description: Reaction type identifier
+ *                           config:
+ *                             type: object
+ *                             description: Reaction configuration parameters
+ *                           delay:
+ *                             type: number
+ *                             description: Optional delay in seconds before executing this reaction
  *                         properties:
  *                           type:
  *                             type: string


### PR DESCRIPTION
This pull request enhances the OpenAPI documentation for the service configuration and mapping routes in the backend by adding detailed response schemas, field descriptions, and example values. These improvements make the API easier to understand and consume for frontend developers and external integrators.

**Service Configuration Documentation Improvements:**

* Added detailed JSON response schemas for endpoints that list and retrieve service configurations, specifying field types and descriptions such as `id`, `service`, `settings`, `is_active`, `created_at`, and `updated_at` (`backend/src/routes/services/configs.ts`). [[1]](diffhunk://#diff-b3e1a0c3a77b966460e8a33ea1924063ff66707d501e0cfa1a16b642539190b0R20-R50) [[2]](diffhunk://#diff-b3e1a0c3a77b966460e8a33ea1924063ff66707d501e0cfa1a16b642539190b0R98-R126)
* Enhanced request and response documentation for creating and updating service configurations, including example values for `service`, `credentials`, and `settings` fields, and specifying the structure of returned configuration objects (`backend/src/routes/services/configs.ts`). [[1]](diffhunk://#diff-b3e1a0c3a77b966460e8a33ea1924063ff66707d501e0cfa1a16b642539190b0R193-R237) [[2]](diffhunk://#diff-b3e1a0c3a77b966460e8a33ea1924063ff66707d501e0cfa1a16b642539190b0R306-R350)

**Service Mapping Documentation Improvements:**

* Clarified the format and requirements for `action` and `reaction` types, including example values and notes that they must exist in a registered service (`backend/src/routes/services/mappings.ts`). [[1]](diffhunk://#diff-262b654a88a9c840077f6145d3f0042298d0b3a2e6b597f6fde9423173fa4b80L146-R151) [[2]](diffhunk://#diff-262b654a88a9c840077f6145d3f0042298d0b3a2e6b597f6fde9423173fa4b80L161-R168)
* Added descriptions and example structures for `action` and `reaction` configuration parameters in mapping objects, improving clarity for integrators (`backend/src/routes/services/mappings.ts`). [[1]](diffhunk://#diff-262b654a88a9c840077f6145d3f0042298d0b3a2e6b597f6fde9423173fa4b80R196-R206) [[2]](diffhunk://#diff-262b654a88a9c840077f6145d3f0042298d0b3a2e6b597f6fde9423173fa4b80R458-R473)