### PR TITLE
fix (backend): swagger issues

### DIFF
--- a/backend/src/routes/services/index.ts
+++ b/backend/src/routes/services/index.ts
@@ -46,7 +46,7 @@ const router = express.Router();
  *                           properties:
  *                             id:
  *                               type: string
- *                               description: Unique identifier for the action (format: service.action)
+ *                               description: "Unique identifier for the action (format: service.action)"
  *                             name:
  *                               type: string
  *                               description: Human-readable name of the action
@@ -74,8 +74,14 @@ const router = express.Router();
  *                                         description: Field name
  *                                       type:
  *                                         type: string
- *                                         enum: [text, email, textarea, select, checkbox, number]
  *                                         description: Type of the field
+ *                                         enum:
+ *                                           - text
+ *                                           - email
+ *                                           - textarea
+ *                                           - select
+ *                                           - checkbox
+ *                                           - number
  *                                       label:
  *                                         type: string
  *                                         description: Human-readable label for the field
@@ -106,7 +112,8 @@ const router = express.Router();
  *                               properties:
  *                                 type:
  *                                   type: string
- *                                   enum: [object]
+ *                                   enum:
+ *                                     - object
  *                                 properties:
  *                                   type: object
  *                                   description: Input properties schema
@@ -210,7 +217,7 @@ router.get(
  *                           properties:
  *                             id:
  *                               type: string
- *                               description: Unique identifier for the reaction (format: service.reaction)
+ *                               description: "Unique identifier for the reaction (format: service.reaction)"
  *                             name:
  *                               type: string
  *                               description: Human-readable name of the reaction
@@ -238,8 +245,14 @@ router.get(
  *                                         description: Field name
  *                                       type:
  *                                         type: string
- *                                         enum: [text, email, textarea, select, checkbox, number]
  *                                         description: Type of the field
+ *                                         enum:
+ *                                           - text
+ *                                           - email
+ *                                           - textarea
+ *                                           - select
+ *                                           - checkbox
+ *                                           - number
  *                                       label:
  *                                         type: string
  *                                         description: Human-readable label for the field
@@ -270,7 +283,8 @@ router.get(
  *                               properties:
  *                                 type:
  *                                   type: string
- *                                   enum: [object]
+ *                                   enum:
+ *                                     - object
  *                                 properties:
  *                                   type: object
  *                                   description: Output properties schema
@@ -370,7 +384,7 @@ router.get(
  *                     properties:
  *                       id:
  *                         type: string
- *                         description: Unique identifier for the action (format: service.action)
+ *                         description: "Unique identifier for the action (format: service.action)"
  *                       name:
  *                         type: string
  *                         description: Human-readable name of the action
@@ -398,8 +412,14 @@ router.get(
  *                                   description: Field name
  *                                 type:
  *                                   type: string
- *                                   enum: [text, email, textarea, select, checkbox, number]
  *                                   description: Type of the field
+ *                                   enum:
+ *                                     - text
+ *                                     - email
+ *                                     - textarea
+ *                                     - select
+ *                                     - checkbox
+ *                                     - number
  *                                 label:
  *                                   type: string
  *                                   description: Human-readable label for the field
@@ -430,7 +450,8 @@ router.get(
  *                         properties:
  *                           type:
  *                             type: string
- *                             enum: [object]
+ *                             enum:
+ *                               - object
  *                           properties:
  *                             type: object
  *                             description: Input properties schema
@@ -559,7 +580,7 @@ router.get(
  *                     properties:
  *                       id:
  *                         type: string
- *                         description: Unique identifier for the reaction (format: service.reaction)
+ *                         description: "Unique identifier for the reaction (format: service.reaction)"
  *                       name:
  *                         type: string
  *                         description: Human-readable name of the reaction
@@ -587,8 +608,14 @@ router.get(
  *                                   description: Field name
  *                                 type:
  *                                   type: string
- *                                   enum: [text, email, textarea, select, checkbox, number]
  *                                   description: Type of the field
+ *                                   enum:
+ *                                     - text
+ *                                     - email
+ *                                     - textarea
+ *                                     - select
+ *                                     - checkbox
+ *                                     - number
  *                                 label:
  *                                   type: string
  *                                   description: Human-readable label for the field
@@ -619,7 +646,8 @@ router.get(
  *                         properties:
  *                           type:
  *                             type: string
- *                             enum: [object]
+ *                             enum:
+ *                               - object
  *                           properties:
  *                             type: object
  *                             description: Output properties schema

--- a/backend/src/routes/services/mappings.ts
+++ b/backend/src/routes/services/mappings.ts
@@ -461,16 +461,6 @@ router.get(
  *                         properties:
  *                           type:
  *                             type: string
- *                             description: Reaction type identifier
- *                           config:
- *                             type: object
- *                             description: Reaction configuration parameters
- *                           delay:
- *                             type: number
- *                             description: Optional delay in seconds before executing this reaction
- *                         properties:
- *                           type:
- *                             type: string
  *                             description: Reaction type in format "service.reaction"
  *                           config:
  *                             type: object


### PR DESCRIPTION
This pull request refactors the OpenAPI schema definitions in `backend/src/routes/services/index.ts` to improve consistency and readability. The main changes involve updating the formatting of enum values and descriptions for various schema properties, ensuring all enum arrays use the expanded YAML list syntax and that string descriptions are properly quoted. Additionally, some redundant schema property definitions in `backend/src/routes/services/mappings.ts` have been cleaned up.

**Schema formatting improvements:**

* Changed enum definitions for field types and object types to use expanded YAML list syntax instead of inline arrays throughout the OpenAPI schemas in `backend/src/routes/services/index.ts`. [[1]](diffhunk://#diff-c854ecfb8a1ce95e3689a144016021605424309ba28da9d02f010623dbbc82e7L77-R84) [[2]](diffhunk://#diff-c854ecfb8a1ce95e3689a144016021605424309ba28da9d02f010623dbbc82e7L109-R116) [[3]](diffhunk://#diff-c854ecfb8a1ce95e3689a144016021605424309ba28da9d02f010623dbbc82e7L241-R255) [[4]](diffhunk://#diff-c854ecfb8a1ce95e3689a144016021605424309ba28da9d02f010623dbbc82e7L273-R287) [[5]](diffhunk://#diff-c854ecfb8a1ce95e3689a144016021605424309ba28da9d02f010623dbbc82e7L401-R422) [[6]](diffhunk://#diff-c854ecfb8a1ce95e3689a144016021605424309ba28da9d02f010623dbbc82e7L433-R454) [[7]](diffhunk://#diff-c854ecfb8a1ce95e3689a144016021605424309ba28da9d02f010623dbbc82e7L590-R618) [[8]](diffhunk://#diff-c854ecfb8a1ce95e3689a144016021605424309ba28da9d02f010623dbbc82e7L622-R650)
* Updated descriptions for `id` fields and other string properties to use quoted strings for consistency in the OpenAPI schema. [[1]](diffhunk://#diff-c854ecfb8a1ce95e3689a144016021605424309ba28da9d02f010623dbbc82e7L49-R49) [[2]](diffhunk://#diff-c854ecfb8a1ce95e3689a144016021605424309ba28da9d02f010623dbbc82e7L213-R220) [[3]](diffhunk://#diff-c854ecfb8a1ce95e3689a144016021605424309ba28da9d02f010623dbbc82e7L373-R387) [[4]](diffhunk://#diff-c854ecfb8a1ce95e3689a144016021605424309ba28da9d02f010623dbbc82e7L562-R583)

**Schema cleanup:**

* Removed redundant property definitions (`type`, `config`, `delay`) and clarified the schema for reaction mappings in `backend/src/routes/services/mappings.ts`.