### PR TITLE
fix(ServicesPage): disable exhaustive-deps rule for user dependency i…

### DIFF
--- a/web/app/services/page.tsx
+++ b/web/app/services/page.tsx
@@ -201,7 +201,8 @@ export default function ServicesPage() {
     if (user) {
       checkServiceStatus();
     }
-  }, [user, services]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user]);
 
   const handleConnect = async (service: Service) => {
     const apiUrl = await getAPIUrl();


### PR DESCRIPTION
This pull request makes a minor adjustment to the dependency array of a `useEffect` hook in the `ServicesPage` component. The change ensures that the effect only depends on `user`, and disables the exhaustive dependencies lint rule to prevent unnecessary re-renders.…n useEffect