### PR TITLE
fix (auth): update logout cookie domain to use environment variable

### DIFF
--- a/backend/src/routes/auth/auth.ts
+++ b/backend/src/routes/auth/auth.ts
@@ -391,7 +391,7 @@ router.post(
       }
 
       const email = (req.auth as { email: string })?.email;
-      res.clearCookie('auth_token', { path: '/', domain: '.nduboi.fr' });
+      res.clearCookie('auth_token', { path: '/', domain: process.env.DOMAIN });
       await createLog(200, 'logout', `User logged out: ${email || 'unknown'}`);
       res.status(200).json({ message: 'Logged out successfully' });
     } catch (err) {


### PR DESCRIPTION
This pull request updates the domain used when clearing the authentication cookie during logout to use the value from the `DOMAIN` environment variable instead of the hardcoded `.nduboi.fr`. This improves flexibility and makes the codebase easier to configure for different environments.