### PR TITLE
feat (backend): auto create webhook

### DIFF
--- a/backend/src/routes/services/mappings.ts
+++ b/backend/src/routes/services/mappings.ts
@@ -2,6 +2,7 @@ import express, { Request, Response } from 'express';
 import token from '../../middleware/token';
 import { serviceRegistry } from '../../services/ServiceRegistry';
 import { mappingService } from './mappings.service';
+import { executionService } from '../../services/ExecutionService';
 import type { Action, Reaction } from '../../types/mapping';
 
 const router = express.Router();
@@ -285,6 +286,19 @@ router.post(
         is_active,
         created_by: userId,
       });
+
+      try {
+        await executionService.ensureExternalWebhooksForMapping(
+          savedMapping,
+          userId
+        );
+        console.log('✅ External webhooks ensured for new mapping');
+      } catch (webhookError) {
+        console.error(
+          '❌ Failed to ensure external webhooks for mapping:',
+          webhookError
+        );
+      }
 
       return res.status(201).json({
         mapping: {


### PR DESCRIPTION
This pull request introduces automatic external webhook creation for service mappings, primarily targeting GitHub actions. Now, whenever a new mapping is created or executed, the system ensures that any required webhooks are set up on the external platform (e.g., GitHub) before reactions are triggered. The documentation is updated to guide service developers on implementing this feature for their own integrations.

**Automatic Webhook Creation and Integration:**

* Added `ensureExternalWebhooksForMapping` method to `ExecutionService`, which dynamically imports and calls the service-specific webhook creation logic (currently for GitHub) before executing mapping reactions. [[1]](diffhunk://#diff-6e4410583ee595c92852653fe5ef54f4549e7db25461dae7b90aa84629a29634R148-R151) [[2]](diffhunk://#diff-6e4410583ee595c92852653fe5ef54f4549e7db25461dae7b90aa84629a29634R536-R553)
* Updated mapping creation endpoint in `mappings.ts` to call `executionService.ensureExternalWebhooksForMapping` after saving a new mapping, ensuring webhooks are created at mapping creation time. [[1]](diffhunk://#diff-262b654a88a9c840077f6145d3f0042298d0b3a2e6b597f6fde9423173fa4b80R290-R302) [[2]](diffhunk://#diff-262b654a88a9c840077f6145d3f0042298d0b3a2e6b597f6fde9423173fa4b80R5)

**Service-specific Webhook Logic (GitHub):**

* Added `ensureWebhookForMapping` function to `services/github/index.ts`, which checks if a webhook is required, extracts repository info, and uses the webhook manager to create the webhook if needed.

**Documentation Improvements:**

* Replaced the old webhook event processing flow with detailed instructions for implementing automatic webhook creation in new services, including code examples and integration steps for the `ExecutionService`.

**Minor Robustness Fix:**

* Improved null-checking in `ExecutionService` when logging mapping details to avoid potential errors if no mapping is found.