### PR TITLE
fix(AuthContext): clear auth token cookie on invalid user data response

### DIFF
--- a/web/contexts/AuthContext.tsx
+++ b/web/contexts/AuthContext.tsx
@@ -64,7 +64,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
           const resp = await api.get<User>({ endpoint: '/user/me' });
           if (!resp.data) {
-            document.cookie = 'auth_token=; Max-Age=0; path=/; domain=' + window.location.hostname;
+            document.cookie =
+              'auth_token=; Max-Age=0; path=/; domain=' +
+              window.location.hostname;
             throw new Error('Invalid user data received');
           }
 

--- a/web/contexts/AuthContext.tsx
+++ b/web/contexts/AuthContext.tsx
@@ -64,6 +64,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
           const resp = await api.get<User>({ endpoint: '/user/me' });
           if (!resp.data) {
+            document.cookie = 'auth_token=; Max-Age=0; path=/; domain=' + window.location.hostname;
             throw new Error('Invalid user data received');
           }
 


### PR DESCRIPTION
This pull request makes a small change to the authentication logic in the `AuthProvider` component. Now, when invalid user data is received, the `auth_token` cookie is explicitly cleared to help prevent issues with stale or invalid authentication tokens.