### PR TITLE
feat (Backend): Add more detail in the backend intrnal server error t…

### DIFF
--- a/backend/src/routes/about/about.ts
+++ b/backend/src/routes/about/about.ts
@@ -108,7 +108,7 @@ router.get('/', async (req: Request, res: Response): Promise<void> => {
     res.status(200).json(response);
   } catch (err) {
     console.error(err);
-    res.status(500).json({ error: 'Internal Server Error' });
+    res.status(500).json({ error: 'Internal Server Error in about route' });
   }
 });
 

--- a/backend/src/routes/auth/auth.ts
+++ b/backend/src/routes/auth/auth.ts
@@ -48,7 +48,7 @@ router.get(
       }
     } catch (err) {
       console.error(err);
-      return res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error in login status route' });
     }
   }
 );
@@ -351,7 +351,7 @@ router.post(
         'register',
         `Error during registration: ${err instanceof Error ? err.message : String(err)}`
       );
-      return res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error in Register' });
     }
   }
 );
@@ -398,7 +398,7 @@ router.post(
       console.error(err);
       const errorMessage = err instanceof Error ? err.message : String(err);
       await createLog(500, 'logout', `Error during logout: ${errorMessage}`);
-      res.status(500).json({ error: 'Internal Server Error' });
+      res.status(500).json({ error: 'Internal Server Error in logout' });
     }
   }
 );
@@ -1050,7 +1050,7 @@ router.post('/forgot-password', async (req: Request, res: Response) => {
       'other',
       `Error during password reset: ${error instanceof Error ? error.message : String(error)}`
     );
-    return res.status(500).json({ error: 'Internal Server Error' });
+    return res.status(500).json({ error: 'Internal Server Error in forgot password' });
   }
 });
 

--- a/backend/src/routes/auth/auth.ts
+++ b/backend/src/routes/auth/auth.ts
@@ -48,7 +48,9 @@ router.get(
       }
     } catch (err) {
       console.error(err);
-      return res.status(500).json({ error: 'Internal Server Error in login status route' });
+      return res
+        .status(500)
+        .json({ error: 'Internal Server Error in login status route' });
     }
   }
 );
@@ -351,7 +353,9 @@ router.post(
         'register',
         `Error during registration: ${err instanceof Error ? err.message : String(err)}`
       );
-      return res.status(500).json({ error: 'Internal Server Error in Register' });
+      return res
+        .status(500)
+        .json({ error: 'Internal Server Error in Register' });
     }
   }
 );
@@ -1050,7 +1054,9 @@ router.post('/forgot-password', async (req: Request, res: Response) => {
       'other',
       `Error during password reset: ${error instanceof Error ? error.message : String(error)}`
     );
-    return res.status(500).json({ error: 'Internal Server Error in forgot password' });
+    return res
+      .status(500)
+      .json({ error: 'Internal Server Error in forgot password' });
   }
 });
 

--- a/backend/src/routes/github/github.ts
+++ b/backend/src/routes/github/github.ts
@@ -61,7 +61,9 @@ router.get(
       });
     } catch (err) {
       console.error(err);
-      return res.status(500).json({ error: 'Internal Server Error in github login status' });
+      return res
+        .status(500)
+        .json({ error: 'Internal Server Error in github login status' });
     }
   }
 );
@@ -139,7 +141,9 @@ router.get(
       });
     } catch (err) {
       console.error(err);
-      return res.status(500).json({ error: 'Internal Server Error in github subscribe status' });
+      return res
+        .status(500)
+        .json({ error: 'Internal Server Error in github subscribe status' });
     }
   }
 );
@@ -193,7 +197,9 @@ router.post(
       });
     } catch (err) {
       console.error(err);
-      return res.status(500).json({ error: 'Internal Server Error in github subscribe' });
+      return res
+        .status(500)
+        .json({ error: 'Internal Server Error in github subscribe' });
     }
   }
 );
@@ -245,7 +251,9 @@ router.post(
       });
     } catch (err) {
       console.error(err);
-      return res.status(500).json({ error: 'Internal Server Error in github unsubscribe' });
+      return res
+        .status(500)
+        .json({ error: 'Internal Server Error in github unsubscribe' });
     }
   }
 );
@@ -275,7 +283,9 @@ router.get(
       return res.status(200).json(webhooks);
     } catch (err) {
       console.error(err);
-      return res.status(500).json({ error: 'Internal Server Error in github webhooks' });
+      return res
+        .status(500)
+        .json({ error: 'Internal Server Error in github webhooks' });
     }
   }
 );
@@ -341,7 +351,9 @@ router.post(
       return res.status(201).json(webhook);
     } catch (err) {
       console.error(err);
-      return res.status(500).json({ error: 'Internal Server Error in github webhooks' });
+      return res
+        .status(500)
+        .json({ error: 'Internal Server Error in github webhooks' });
     }
   }
 );
@@ -383,7 +395,9 @@ router.delete(
       return res.status(200).json({ message: 'Webhook deleted successfully' });
     } catch (err) {
       console.error(err);
-      return res.status(500).json({ error: 'Internal Server Error in github webhooks' });
+      return res
+        .status(500)
+        .json({ error: 'Internal Server Error in github webhooks' });
     }
   }
 );

--- a/backend/src/routes/github/github.ts
+++ b/backend/src/routes/github/github.ts
@@ -61,7 +61,7 @@ router.get(
       });
     } catch (err) {
       console.error(err);
-      return res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error in github login status' });
     }
   }
 );
@@ -139,7 +139,7 @@ router.get(
       });
     } catch (err) {
       console.error(err);
-      return res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error in github subscribe status' });
     }
   }
 );
@@ -193,7 +193,7 @@ router.post(
       });
     } catch (err) {
       console.error(err);
-      return res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error in github subscribe' });
     }
   }
 );
@@ -245,7 +245,7 @@ router.post(
       });
     } catch (err) {
       console.error(err);
-      return res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error in github unsubscribe' });
     }
   }
 );
@@ -275,7 +275,7 @@ router.get(
       return res.status(200).json(webhooks);
     } catch (err) {
       console.error(err);
-      return res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error in github webhooks' });
     }
   }
 );
@@ -341,7 +341,7 @@ router.post(
       return res.status(201).json(webhook);
     } catch (err) {
       console.error(err);
-      return res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error in github webhooks' });
     }
   }
 );
@@ -383,7 +383,7 @@ router.delete(
       return res.status(200).json({ message: 'Webhook deleted successfully' });
     } catch (err) {
       console.error(err);
-      return res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error in github webhooks' });
     }
   }
 );

--- a/backend/src/routes/google/google.ts
+++ b/backend/src/routes/google/google.ts
@@ -60,7 +60,9 @@ router.get(
       });
     } catch (err) {
       console.error(err);
-      return res.status(500).json({ error: 'Internal Server Error in google login status' });
+      return res
+        .status(500)
+        .json({ error: 'Internal Server Error in google login status' });
     }
   }
 );
@@ -138,7 +140,9 @@ router.get(
       });
     } catch (err) {
       console.error(err);
-      return res.status(500).json({ error: 'Internal Server Error in google subscribe status' });
+      return res
+        .status(500)
+        .json({ error: 'Internal Server Error in google subscribe status' });
     }
   }
 );
@@ -198,7 +202,9 @@ router.post(
       });
     } catch (err) {
       console.error(err);
-      return res.status(500).json({ error: 'Internal Server Error in google subscribe' });
+      return res
+        .status(500)
+        .json({ error: 'Internal Server Error in google subscribe' });
     }
   }
 );
@@ -252,7 +258,9 @@ router.post(
       });
     } catch (err) {
       console.error(err);
-      return res.status(500).json({ error: 'Internal Server Error in google unsubscribe' });
+      return res
+        .status(500)
+        .json({ error: 'Internal Server Error in google unsubscribe' });
     }
   }
 );

--- a/backend/src/routes/google/google.ts
+++ b/backend/src/routes/google/google.ts
@@ -60,7 +60,7 @@ router.get(
       });
     } catch (err) {
       console.error(err);
-      return res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error in google login status' });
     }
   }
 );
@@ -138,7 +138,7 @@ router.get(
       });
     } catch (err) {
       console.error(err);
-      return res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error in google subscribe status' });
     }
   }
 );
@@ -198,7 +198,7 @@ router.post(
       });
     } catch (err) {
       console.error(err);
-      return res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error in google subscribe' });
     }
   }
 );
@@ -252,7 +252,7 @@ router.post(
       });
     } catch (err) {
       console.error(err);
-      return res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error in google unsubscribe' });
     }
   }
 );

--- a/backend/src/routes/services/configs.ts
+++ b/backend/src/routes/services/configs.ts
@@ -72,7 +72,9 @@ router.get(
       });
     } catch (err) {
       console.error('Error fetching service configs:', err);
-      return res.status(500).json({ error: 'Internal Server Error in service configs' });
+      return res
+        .status(500)
+        .json({ error: 'Internal Server Error in service configs' });
     }
   }
 );
@@ -164,7 +166,9 @@ router.get(
       });
     } catch (err) {
       console.error('Error fetching service config:', err);
-      return res.status(500).json({ error: 'Internal Server Error in service config id' });
+      return res
+        .status(500)
+        .json({ error: 'Internal Server Error in service config id' });
     }
   }
 );
@@ -275,7 +279,9 @@ router.post(
       });
     } catch (err) {
       console.error('Error creating/updating service config:', err);
-      return res.status(500).json({ error: 'Internal Server Error in service configs post' });
+      return res
+        .status(500)
+        .json({ error: 'Internal Server Error in service configs post' });
     }
   }
 );
@@ -395,7 +401,9 @@ router.put(
       });
     } catch (err) {
       console.error('Error updating service config:', err);
-      return res.status(500).json({ error: 'Internal Server Error in put service config :id' });
+      return res
+        .status(500)
+        .json({ error: 'Internal Server Error in put service config :id' });
     }
   }
 );
@@ -451,7 +459,9 @@ router.delete(
       });
     } catch (err) {
       console.error('Error deleting service config:', err);
-      return res.status(500).json({ error: 'Internal Server Error in delete service config' });
+      return res
+        .status(500)
+        .json({ error: 'Internal Server Error in delete service config' });
     }
   }
 );

--- a/backend/src/routes/services/configs.ts
+++ b/backend/src/routes/services/configs.ts
@@ -72,7 +72,7 @@ router.get(
       });
     } catch (err) {
       console.error('Error fetching service configs:', err);
-      return res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error in service configs' });
     }
   }
 );
@@ -164,7 +164,7 @@ router.get(
       });
     } catch (err) {
       console.error('Error fetching service config:', err);
-      return res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error in service config id' });
     }
   }
 );
@@ -275,7 +275,7 @@ router.post(
       });
     } catch (err) {
       console.error('Error creating/updating service config:', err);
-      return res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error in service configs post' });
     }
   }
 );
@@ -395,7 +395,7 @@ router.put(
       });
     } catch (err) {
       console.error('Error updating service config:', err);
-      return res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error in put service config :id' });
     }
   }
 );
@@ -451,7 +451,7 @@ router.delete(
       });
     } catch (err) {
       console.error('Error deleting service config:', err);
-      return res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error in delete service config' });
     }
   }
 );

--- a/backend/src/routes/services/index.ts
+++ b/backend/src/routes/services/index.ts
@@ -170,7 +170,7 @@ router.get(
       });
     } catch (err) {
       console.error('Error fetching services with actions:', err);
-      return res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error in get services actions' });
     }
   }
 );
@@ -341,7 +341,7 @@ router.get(
       });
     } catch (err) {
       console.error('Error fetching services with reactions:', err);
-      return res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error in get services reactions' });
     }
   }
 );
@@ -537,7 +537,7 @@ router.get(
       });
     } catch (err) {
       console.error('Error fetching service actions:', err);
-      return res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error in get id actions' });
     }
   }
 );
@@ -733,7 +733,7 @@ router.get(
       });
     } catch (err) {
       console.error('Error fetching service reactions:', err);
-      return res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error in get id reactions' });
     }
   }
 );

--- a/backend/src/routes/services/index.ts
+++ b/backend/src/routes/services/index.ts
@@ -170,7 +170,9 @@ router.get(
       });
     } catch (err) {
       console.error('Error fetching services with actions:', err);
-      return res.status(500).json({ error: 'Internal Server Error in get services actions' });
+      return res
+        .status(500)
+        .json({ error: 'Internal Server Error in get services actions' });
     }
   }
 );
@@ -341,7 +343,9 @@ router.get(
       });
     } catch (err) {
       console.error('Error fetching services with reactions:', err);
-      return res.status(500).json({ error: 'Internal Server Error in get services reactions' });
+      return res
+        .status(500)
+        .json({ error: 'Internal Server Error in get services reactions' });
     }
   }
 );
@@ -537,7 +541,9 @@ router.get(
       });
     } catch (err) {
       console.error('Error fetching service actions:', err);
-      return res.status(500).json({ error: 'Internal Server Error in get id actions' });
+      return res
+        .status(500)
+        .json({ error: 'Internal Server Error in get id actions' });
     }
   }
 );
@@ -733,7 +739,9 @@ router.get(
       });
     } catch (err) {
       console.error('Error fetching service reactions:', err);
-      return res.status(500).json({ error: 'Internal Server Error in get id reactions' });
+      return res
+        .status(500)
+        .json({ error: 'Internal Server Error in get id reactions' });
     }
   }
 );

--- a/backend/src/routes/services/mappings.ts
+++ b/backend/src/routes/services/mappings.ts
@@ -315,7 +315,7 @@ router.post(
       });
     } catch (err) {
       console.error('Error creating mapping:', err);
-      return res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error in create mapping' });
     }
   }
 );
@@ -416,7 +416,7 @@ router.get(
       });
     } catch (err) {
       console.error('Error fetching mappings:', err);
-      return res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error in fetching mappings' });
     }
   }
 );
@@ -561,7 +561,7 @@ router.get(
       });
     } catch (err) {
       console.error('Error fetching mapping:', err);
-      return res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error in get mapping by id' });
     }
   }
 );
@@ -647,7 +647,7 @@ router.delete(
       });
     } catch (err) {
       console.error('Error deleting mapping:', err);
-      return res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error in deleting mapping' });
     }
   }
 );

--- a/backend/src/routes/services/mappings.ts
+++ b/backend/src/routes/services/mappings.ts
@@ -315,7 +315,9 @@ router.post(
       });
     } catch (err) {
       console.error('Error creating mapping:', err);
-      return res.status(500).json({ error: 'Internal Server Error in create mapping' });
+      return res
+        .status(500)
+        .json({ error: 'Internal Server Error in create mapping' });
     }
   }
 );
@@ -416,7 +418,9 @@ router.get(
       });
     } catch (err) {
       console.error('Error fetching mappings:', err);
-      return res.status(500).json({ error: 'Internal Server Error in fetching mappings' });
+      return res
+        .status(500)
+        .json({ error: 'Internal Server Error in fetching mappings' });
     }
   }
 );
@@ -561,7 +565,9 @@ router.get(
       });
     } catch (err) {
       console.error('Error fetching mapping:', err);
-      return res.status(500).json({ error: 'Internal Server Error in get mapping by id' });
+      return res
+        .status(500)
+        .json({ error: 'Internal Server Error in get mapping by id' });
     }
   }
 );
@@ -647,7 +653,9 @@ router.delete(
       });
     } catch (err) {
       console.error('Error deleting mapping:', err);
-      return res.status(500).json({ error: 'Internal Server Error in deleting mapping' });
+      return res
+        .status(500)
+        .json({ error: 'Internal Server Error in deleting mapping' });
     }
   }
 );

--- a/backend/src/routes/user/user.ts
+++ b/backend/src/routes/user/user.ts
@@ -52,7 +52,7 @@ router.get(
       return res.status(200).json(users);
     } catch (err) {
       console.error(err);
-      return res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error get all users' });
     }
   }
 );
@@ -101,7 +101,7 @@ router.get(
     } catch (err) {
       console.error(err);
       await createLog(500, 'user', `Internal Server Error: ${err}`);
-      return res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error in get me' });
     }
   }
 );
@@ -189,7 +189,7 @@ router.get(
       return res.status(200).json(user);
     } catch (err: unknown) {
       console.error(err);
-      return res.status(500).json({ msg: 'Internal server error' });
+      return res.status(500).json({ msg: 'Internal server error in get user :data' });
     }
   }
 );

--- a/backend/src/routes/user/user.ts
+++ b/backend/src/routes/user/user.ts
@@ -52,7 +52,9 @@ router.get(
       return res.status(200).json(users);
     } catch (err) {
       console.error(err);
-      return res.status(500).json({ error: 'Internal Server Error get all users' });
+      return res
+        .status(500)
+        .json({ error: 'Internal Server Error get all users' });
     }
   }
 );
@@ -189,7 +191,9 @@ router.get(
       return res.status(200).json(user);
     } catch (err: unknown) {
       console.error(err);
-      return res.status(500).json({ msg: 'Internal server error in get user :data' });
+      return res
+        .status(500)
+        .json({ msg: 'Internal server error in get user :data' });
     }
   }
 );

--- a/backend/src/webhooks/index.ts
+++ b/backend/src/webhooks/index.ts
@@ -50,7 +50,9 @@ router.post(
       await handler.handle(req, res);
     } catch (error) {
       console.error(`Error handling webhook for service '${service}':`, error);
-      return res.status(500).json({ error: 'Internal server error in updates service webhook' });
+      return res
+        .status(500)
+        .json({ error: 'Internal server error in updates service webhook' });
     }
   }
 );

--- a/backend/src/webhooks/index.ts
+++ b/backend/src/webhooks/index.ts
@@ -50,7 +50,7 @@ router.post(
       await handler.handle(req, res);
     } catch (error) {
       console.error(`Error handling webhook for service '${service}':`, error);
-      return res.status(500).json({ error: 'Internal server error' });
+      return res.status(500).json({ error: 'Internal server error in updates service webhook' });
     }
   }
 );


### PR DESCRIPTION
…o identify easier where the error comes from
This pull request updates error handling across multiple backend route files to make server error responses more descriptive. Instead of returning a generic "Internal Server Error" message, each route now sends an error message that specifies the route or context in which the error occurred. This will help with debugging and log analysis by making it easier to identify where errors originate.

The most important changes are:

**Improved Error Messages in Route Handlers**

- Updated all `res.status(500).json({ error: ... })` responses in the `auth.ts` routes to include the specific route context in the error message, such as "Internal Server Error in login status route", "in Register", "in logout", and "in forgot password". [[1]](diffhunk://#diff-278b414c47d2934820f3d227a5faa32d485d5e46baa854fe8317b38ee9f5609fL51-R51) [[2]](diffhunk://#diff-278b414c47d2934820f3d227a5faa32d485d5e46baa854fe8317b38ee9f5609fL354-R354) [[3]](diffhunk://#diff-278b414c47d2934820f3d227a5faa32d485d5e46baa854fe8317b38ee9f5609fL401-R401) [[4]](diffhunk://#diff-278b414c47d2934820f3d227a5faa32d485d5e46baa854fe8317b38ee9f5609fL1053-R1053)
- Enhanced error messages in the `github.ts` routes to specify the failing operation, for example "Internal Server Error in github login status", "in github subscribe status", "in github subscribe", "in github unsubscribe", and "in github webhooks". [[1]](diffhunk://#diff-88ecf0bcbf05fc179b4d522356ff1500d0df5a9c6d6dddf8682ea58858759553L64-R64) [[2]](diffhunk://#diff-88ecf0bcbf05fc179b4d522356ff1500d0df5a9c6d6dddf8682ea58858759553L142-R142) [[3]](diffhunk://#diff-88ecf0bcbf05fc179b4d522356ff1500d0df5a9c6d6dddf8682ea58858759553L196-R196) [[4]](diffhunk://#diff-88ecf0bcbf05fc179b4d522356ff1500d0df5a9c6d6dddf8682ea58858759553L248-R248) [[5]](diffhunk://#diff-88ecf0bcbf05fc179b4d522356ff1500d0df5a9c6d6dddf8682ea58858759553L278-R278) [[6]](diffhunk://#diff-88ecf0bcbf05fc179b4d522356ff1500d0df5a9c6d6dddf8682ea58858759553L344-R344) [[7]](diffhunk://#diff-88ecf0bcbf05fc179b4d522356ff1500d0df5a9c6d6dddf8682ea58858759553L386-R386)
- Applied similar improvements in the `google.ts` routes, clarifying errors with messages like "Internal Server Error in google login status", "in google subscribe status", "in google subscribe", and "in google unsubscribe". [[1]](diffhunk://#diff-85a3c3ddfe49e911f2a41cb27fb25ad92cd277a912d4b5272d7908c20cd90db7L63-R63) [[2]](diffhunk://#diff-85a3c3ddfe49e911f2a41cb27fb25ad92cd277a912d4b5272d7908c20cd90db7L141-R141) [[3]](diffhunk://#diff-85a3c3ddfe49e911f2a41cb27fb25ad92cd277a912d4b5272d7908c20cd90db7L201-R201) [[4]](diffhunk://#diff-85a3c3ddfe49e911f2a41cb27fb25ad92cd277a912d4b5272d7908c20cd90db7L255-R255)
- Updated error responses in `services/configs.ts` and `services/index.ts` to include route-specific details, such as "Internal Server Error in service configs", "in service config id", "in service configs post", "in put service config :id", "in delete service config", "in get services actions", "in get services reactions", "in get id actions", and "in get id reactions". [[1]](diffhunk://#diff-b3e1a0c3a77b966460e8a33ea1924063ff66707d501e0cfa1a16b642539190b0L75-R75) [[2]](diffhunk://#diff-b3e1a0c3a77b966460e8a33ea1924063ff66707d501e0cfa1a16b642539190b0L167-R167) [[3]](diffhunk://#diff-b3e1a0c3a77b966460e8a33ea1924063ff66707d501e0cfa1a16b642539190b0L278-R278) [[4]](diffhunk://#diff-b3e1a0c3a77b966460e8a33ea1924063ff66707d501e0cfa1a16b642539190b0L398-R398) [[5]](diffhunk://#diff-b3e1a0c3a77b966460e8a33ea1924063ff66707d501e0cfa1a16b642539190b0L454-R454) [[6]](diffhunk://#diff-c854ecfb8a1ce95e3689a144016021605424309ba28da9d02f010623dbbc82e7L173-R173) [[7]](diffhunk://#diff-c854ecfb8a1ce95e3689a144016021605424309ba28da9d02f010623dbbc82e7L344-R344) [[8]](diffhunk://#diff-c854ecfb8a1ce95e3689a144016021605424309ba28da9d02f010623dbbc82e7L540-R540) [[9]](diffhunk://#diff-c854ecfb8a1ce95e3689a144016021605424309ba28da9d02f010623dbbc82e7L736-R736)
- Improved error messages in `services/mappings.ts` and `user.ts` to clarify the context of server errors, e.g., "Internal Server Error in create mapping", "in fetching mappings", "in get mapping by id", "in deleting mapping", "get all users", "in get me", and "in get user :data". [[1]](diffhunk://#diff-262b654a88a9c840077f6145d3f0042298d0b3a2e6b597f6fde9423173fa4b80L318-R318) [[2]](diffhunk://#diff-262b654a88a9c840077f6145d3f0042298d0b3a2e6b597f6fde9423173fa4b80L419-R419) [[3]](diffhunk://#diff-262b654a88a9c840077f6145d3f0042298d0b3a2e6b597f6fde9423173fa4b80L564-R564) [[4]](diffhunk://#diff-262b654a88a9c840077f6145d3f0042298d0b3a2e6b597f6fde9423173fa4b80L650-R650) [[5]](diffhunk://#diff-0d1aa3b90ea36ea9fd650a1be8f14d9f33b6c9f81f831240ba4226df619c5bcbL55-R55) [[6]](diffhunk://#diff-0d1aa3b90ea36ea9fd650a1be8f14d9f33b6c9f81f831240ba4226df619c5bcbL104-R104) [[7]](diffhunk://#diff-0d1aa3b90ea36ea9fd650a1be8f14d9f33b6c9f81f831240ba4226df619c5bcbL192-R192)
- Changed the error response in the webhooks handler to "Internal server error in updates service webhook" for better traceability.
- Updated the about route to specify "Internal Server Error in about route" in error responses.

These changes make server-side errors more actionable and easier to trace during development and in production logs.