### PR TITLE
Create apk downlaod

### DIFF
--- a/deployment/Dockerfile.mobile
+++ b/deployment/Dockerfile.mobile
@@ -32,3 +32,6 @@ RUN mkdir -p /app/build
 COPY --from=builder /app/build/app/outputs/flutter-apk/app-release.apk /app/build/area.apk
 
 WORKDIR /app
+
+# Copy the APK to the volume when container starts
+CMD ["sh", "-c", "cp /app/build/area.apk /app/build/area.apk && sleep infinity"]

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - FRONTEND_URL=${FRONTEND_URL}
       - NODE_PORT=${NODE_PORT}
     volumes:
-      - mobile_build:/usr/share/nginx/html/mobile
+      - mobile_build:/app/mobile
     depends_on:
       - client_mobile
       - server

--- a/web/app/client.apk/route.ts
+++ b/web/app/client.apk/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export async function GET(request: NextRequest) {
+  try {
+    void request;
+    const apkPath = path.join(process.cwd(), 'mobile', 'area.apk');
+
+    try {
+      await fs.access(apkPath);
+    } catch (error) {
+      void error;
+      console.error('APK file not found:', apkPath);
+      return new NextResponse('APK file not found', { status: 404 });
+    }
+
+    const fileBuffer = await fs.readFile(apkPath);
+
+    return new NextResponse(new Uint8Array(fileBuffer), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/vnd.android.package-archive',
+        'Content-Disposition': 'attachment; filename="area.apk"',
+        'Content-Length': fileBuffer.length.toString(),
+      },
+    });
+  } catch (error) {
+    console.error('Error serving APK file:', error);
+    return new NextResponse('Internal Server Error', { status: 500 });
+  }
+}


### PR DESCRIPTION
This pull request introduces changes to support serving the mobile APK file (`area.apk`) through the web application and updates the deployment setup to ensure the APK is correctly copied and mounted in the container environment. The main areas of change are the addition of an API route to serve the APK, updates to Docker and Docker Compose configurations, and improvements to how the APK is handled at runtime.

**API for serving APK:**

- Added a new API route `web/app/client.apk/route.ts` that serves the `area.apk` file from the `/app/mobile` directory, returning a 404 if the file is missing and handling errors gracefully.

**Deployment and containerization updates:**

- Updated `deployment/docker-compose.yml` to mount the `mobile_build` volume at `/app/mobile` instead of the previous path, ensuring the APK is accessible to the web application.
- Modified `deployment/Dockerfile.mobile` to add a startup command (`CMD`) that copies the built APK to the correct location (`/app/build/area.apk`) and keeps the container running, which ensures the APK is available in the mounted volume.