### PR TITLE
spotify service reactions

### DIFF
--- a/backend/src/config/passport.ts
+++ b/backend/src/config/passport.ts
@@ -450,7 +450,8 @@ passport.use(
       clientID: process.env.SERVICE_SPOTIFY_CLIENT_ID || '',
       clientSecret: process.env.SERVICE_SPOTIFY_CLIENT_SECRET || '',
       callbackURL: process.env.SERVICE_SPOTIFY_REDIRECT_URI || '',
-      scope: 'user-read-email user-read-private user-modify-playback-state playlist-modify-public playlist-modify-private user-read-playback-state user-library-modify',
+      scope:
+        'user-read-email user-read-private user-modify-playback-state playlist-modify-public playlist-modify-private user-read-playback-state user-library-modify',
       passReqToCallback: true,
     },
     async (
@@ -488,7 +489,9 @@ passport.use(
         const tokenData = {
           access_token: accessToken,
           token_type: 'bearer',
-          scope: params.scope || 'user-read-email user-read-private user-modify-playback-state playlist-modify-public playlist-modify-private user-read-playback-state user-library-modify',
+          scope:
+            params.scope ||
+            'user-read-email user-read-private user-modify-playback-state playlist-modify-public playlist-modify-private user-read-playback-state user-library-modify',
           expires_in: params.expires_in || 3600,
           refresh_token: refreshToken,
         };

--- a/backend/src/config/passport.ts
+++ b/backend/src/config/passport.ts
@@ -450,14 +450,14 @@ passport.use(
       clientID: process.env.SERVICE_SPOTIFY_CLIENT_ID || '',
       clientSecret: process.env.SERVICE_SPOTIFY_CLIENT_SECRET || '',
       callbackURL: process.env.SERVICE_SPOTIFY_REDIRECT_URI || '',
-      scope: 'user-read-email user-read-private',
+      scope: 'user-read-email user-read-private user-modify-playback-state playlist-modify-public playlist-modify-private user-read-playback-state user-library-modify',
       passReqToCallback: true,
     },
     async (
       req: Request,
       accessToken: string,
       refreshToken: string,
-      params: { expires_in?: number },
+      params: { expires_in?: number; scope?: string },
       profile: unknown,
       done: unknown
     ) => {
@@ -488,7 +488,7 @@ passport.use(
         const tokenData = {
           access_token: accessToken,
           token_type: 'bearer',
-          scope: 'user-read-email user-read-private',
+          scope: params.scope || 'user-read-email user-read-private user-modify-playback-state playlist-modify-public playlist-modify-private user-read-playback-state user-library-modify',
           expires_in: params.expires_in || 3600,
           refresh_token: refreshToken,
         };

--- a/backend/src/routes/auth/auth.ts
+++ b/backend/src/routes/auth/auth.ts
@@ -918,7 +918,6 @@ router.get(
       return res.status(401).json({ error: 'Authentication required' });
     }
     passport.authenticate('spotify-subscribe', {
-      scope: 'user-read-email user-read-private',
       session: false,
     })(req, res, next);
   }

--- a/backend/src/services/services/spotify/executor.ts
+++ b/backend/src/services/services/spotify/executor.ts
@@ -1,0 +1,471 @@
+import type {
+  ReactionExecutor,
+  ReactionExecutionContext,
+  ReactionExecutionResult,
+} from '../../../types/service';
+import { spotifyOAuth } from './oauth';
+
+interface SpotifyPlaybackState {
+  is_playing: boolean;
+  currently_playing_type: string;
+  item?: {
+    id: string;
+    name: string;
+    uri: string;
+    type: string;
+  };
+  device?: {
+    id: string;
+    name: string;
+    type: string;
+    volume_percent: number;
+  };
+}
+
+interface SpotifyPlayRequest {
+  uris: string[];
+  device_id?: string;
+}
+
+export class SpotifyReactionExecutor implements ReactionExecutor {
+  private apiBaseUrl: string;
+
+  constructor() {
+    this.apiBaseUrl = process.env.SERVICE_SPOTIFY_API_BASE_URL || 'https://api.spotify.com/v1';
+  }
+
+  async execute(
+    context: ReactionExecutionContext
+  ): Promise<ReactionExecutionResult> {
+    const { reaction, serviceConfig } = context;
+
+    try {
+      const accessToken = serviceConfig.credentials?.access_token;
+      if (!accessToken) {
+        return {
+          success: false,
+          error: 'Spotify access token not configured',
+        };
+      }
+
+      // Validate and refresh token if needed
+      const userToken = await spotifyOAuth.getUserToken(context.event.user_id);
+      if (!userToken) {
+        return {
+          success: false,
+          error: 'Spotify access token not found or expired',
+        };
+      }
+
+      const validToken = userToken.token_value;
+
+      switch (reaction.type) {
+        case 'spotify.skip_track':
+          return await this.skipTrack(validToken);
+        case 'spotify.pause_resume_playback':
+          return await this.pauseResumePlayback(validToken);
+        case 'spotify.add_song_to_playlist':
+          return await this.addSongToPlaylist(reaction.config, validToken);
+        case 'spotify.play_specific_track':
+          return await this.playSpecificTrack(reaction.config, validToken);
+        case 'spotify.set_volume':
+          return await this.setVolume(reaction.config, validToken);
+        default:
+          return {
+            success: false,
+            error: `Unknown reaction type: ${reaction.type}`,
+          };
+      }
+    } catch (error) {
+      console.error('Spotify reaction execution error:', error);
+      return {
+        success: false,
+        error: (error as Error).message,
+      };
+    }
+  }
+
+  private async skipTrack(accessToken: string): Promise<ReactionExecutionResult> {
+    try {
+      const response = await fetch(`${this.apiBaseUrl}/me/player/next`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (response.status === 204) {
+        return {
+          success: true,
+          output: { success: true },
+        };
+      }
+
+      if (response.status === 403) {
+        return {
+          success: false,
+          error: 'No active device found. Please start Spotify on a device first.',
+        };
+      }
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        return {
+          success: false,
+          error: `Spotify API error: ${response.status} - ${errorData.error?.message || 'Unknown error'}`,
+        };
+      }
+
+      return {
+        success: true,
+        output: { success: true },
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: `Network error while skipping track: ${(error as Error).message}`,
+      };
+    }
+  }
+
+  private async pauseResumePlayback(accessToken: string): Promise<ReactionExecutionResult> {
+    try {
+      // First get current playback state
+      const stateResponse = await fetch(`${this.apiBaseUrl}/me/player`, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (!stateResponse.ok) {
+        if (stateResponse.status === 204) {
+          return {
+            success: false,
+            error: 'No active playback found',
+          };
+        }
+        const errorData = await stateResponse.json().catch(() => ({}));
+        return {
+          success: false,
+          error: `Failed to get playback state: ${errorData.error?.message || 'Unknown error'}`,
+        };
+      }
+
+      const playbackState: SpotifyPlaybackState = await stateResponse.json();
+      const isPlaying = playbackState.is_playing;
+
+      // Toggle playback
+      const endpoint = isPlaying ? '/me/player/pause' : '/me/player/play';
+      const method = isPlaying ? 'PUT' : 'PUT';
+
+      const response = await fetch(`${this.apiBaseUrl}${endpoint}`, {
+        method,
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (response.status === 204) {
+        return {
+          success: true,
+          output: {
+            action: isPlaying ? 'pause' : 'resume',
+            success: true,
+          },
+        };
+      }
+
+      if (response.status === 403) {
+        return {
+          success: false,
+          error: 'No active device found. Please start Spotify on a device first.',
+        };
+      }
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        return {
+          success: false,
+          error: `Spotify API error: ${response.status} - ${errorData.error?.message || 'Unknown error'}`,
+        };
+      }
+
+      return {
+        success: true,
+        output: {
+          action: isPlaying ? 'pause' : 'resume',
+          success: true,
+        },
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: `Network error while toggling playback: ${(error as Error).message}`,
+      };
+    }
+  }
+
+  private async addSongToPlaylist(
+    config: Record<string, unknown>,
+    accessToken: string
+  ): Promise<ReactionExecutionResult> {
+    const { playlist_id, track_uri } = config as {
+      playlist_id: string;
+      track_uri?: string;
+    };
+
+    if (!playlist_id) {
+      return {
+        success: false,
+        error: 'Playlist ID is required',
+      };
+    }
+
+    let finalTrackUri = track_uri;
+
+    // If no track URI provided, get currently playing track
+    if (!finalTrackUri) {
+      try {
+        const stateResponse = await fetch(`${this.apiBaseUrl}/me/player`, {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Content-Type': 'application/json',
+          },
+        });
+
+        if (!stateResponse.ok) {
+          return {
+            success: false,
+            error: 'No currently playing track found and no track URI provided',
+          };
+        }
+
+        const playbackState: SpotifyPlaybackState = await stateResponse.json();
+        if (!playbackState.item?.uri) {
+          return {
+            success: false,
+            error: 'No currently playing track found',
+          };
+        }
+
+        finalTrackUri = playbackState.item.uri;
+      } catch (error) {
+        return {
+          success: false,
+          error: `Failed to get currently playing track: ${(error as Error).message}`,
+        };
+      }
+    }
+
+    try {
+      const response = await fetch(
+        `${this.apiBaseUrl}/playlists/${playlist_id}/tracks`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            uris: [finalTrackUri],
+          }),
+        }
+      );
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        return {
+          success: false,
+          error: `Spotify API error: ${response.status} - ${errorData.error?.message || 'Unknown error'}`,
+        };
+      }
+
+      return {
+        success: true,
+        output: {
+          playlist_id,
+          track_uri: finalTrackUri,
+          success: true,
+        },
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: `Network error while adding song to playlist: ${(error as Error).message}`,
+      };
+    }
+  }
+
+  private async playSpecificTrack(
+    config: Record<string, unknown>,
+    accessToken: string
+  ): Promise<ReactionExecutionResult> {
+    const { uri, device_id } = config as {
+      uri: string;
+      device_id?: string;
+    };
+
+    if (!uri) {
+      return {
+        success: false,
+        error: 'URI is required',
+      };
+    }
+
+    try {
+      const requestBody: SpotifyPlayRequest = {
+        uris: [uri],
+      };
+
+      if (device_id) {
+        requestBody.device_id = device_id;
+      }
+
+      const response = await fetch(`${this.apiBaseUrl}/me/player/play`, {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(requestBody),
+      });
+
+      if (response.status === 204) {
+        return {
+          success: true,
+          output: {
+            uri,
+            device_id: device_id || null,
+            success: true,
+          },
+        };
+      }
+
+      if (response.status === 403) {
+        return {
+          success: false,
+          error: 'No active device found. Please start Spotify on a device first.',
+        };
+      }
+
+      if (response.status === 404) {
+        return {
+          success: false,
+          error: 'Device not found. Check the device ID.',
+        };
+      }
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        return {
+          success: false,
+          error: `Spotify API error: ${response.status} - ${errorData.error?.message || 'Unknown error'}`,
+        };
+      }
+
+      return {
+        success: true,
+        output: {
+          uri,
+          device_id: device_id || null,
+          success: true,
+        },
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: `Network error while playing track: ${(error as Error).message}`,
+      };
+    }
+  }
+
+  private async setVolume(
+    config: Record<string, unknown>,
+    accessToken: string
+  ): Promise<ReactionExecutionResult> {
+    const { volume_percent, device_id } = config as {
+      volume_percent: number;
+      device_id?: string;
+    };
+
+    if (volume_percent === undefined || volume_percent < 0 || volume_percent > 100) {
+      return {
+        success: false,
+        error: 'Volume percent must be between 0 and 100',
+      };
+    }
+
+    try {
+      const params = new URLSearchParams({
+        volume_percent: Math.round(volume_percent).toString(),
+      });
+
+      if (device_id) {
+        params.append('device_id', device_id);
+      }
+
+      const response = await fetch(
+        `${this.apiBaseUrl}/me/player/volume?${params.toString()}`,
+        {
+          method: 'PUT',
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+
+      if (response.status === 204) {
+        return {
+          success: true,
+          output: {
+            volume_percent: Math.round(volume_percent),
+            device_id: device_id || null,
+            success: true,
+          },
+        };
+      }
+
+      if (response.status === 403) {
+        return {
+          success: false,
+          error: 'No active device found. Please start Spotify on a device first.',
+        };
+      }
+
+      if (response.status === 404) {
+        return {
+          success: false,
+          error: 'Device not found. Check the device ID.',
+        };
+      }
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        return {
+          success: false,
+          error: `Spotify API error: ${response.status} - ${errorData.error?.message || 'Unknown error'}`,
+        };
+      }
+
+      return {
+        success: true,
+        output: {
+          volume_percent: Math.round(volume_percent),
+          device_id: device_id || null,
+          success: true,
+        },
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: `Network error while setting volume: ${(error as Error).message}`,
+      };
+    }
+  }
+}
+
+export const spotifyReactionExecutor = new SpotifyReactionExecutor();

--- a/backend/src/services/services/spotify/executor.ts
+++ b/backend/src/services/services/spotify/executor.ts
@@ -31,7 +31,9 @@ export class SpotifyReactionExecutor implements ReactionExecutor {
   private apiBaseUrl: string;
 
   constructor() {
-    this.apiBaseUrl = (process.env.SERVICE_SPOTIFY_API_BASE_URL || 'https://api.spotify.com') + '/v1';
+    this.apiBaseUrl =
+      (process.env.SERVICE_SPOTIFY_API_BASE_URL || 'https://api.spotify.com') +
+      '/v1';
   }
 
   async execute(
@@ -85,7 +87,9 @@ export class SpotifyReactionExecutor implements ReactionExecutor {
     }
   }
 
-  private async skipTrack(accessToken: string): Promise<ReactionExecutionResult> {
+  private async skipTrack(
+    accessToken: string
+  ): Promise<ReactionExecutionResult> {
     try {
       const response = await fetch(`${this.apiBaseUrl}/me/player/next`, {
         method: 'POST',
@@ -105,7 +109,8 @@ export class SpotifyReactionExecutor implements ReactionExecutor {
       if (response.status === 403) {
         return {
           success: false,
-          error: 'No active device found. Please start Spotify on a device first.',
+          error:
+            'No active device found. Please start Spotify on a device first.',
         };
       }
 
@@ -129,7 +134,9 @@ export class SpotifyReactionExecutor implements ReactionExecutor {
     }
   }
 
-  private async pauseResumePlayback(accessToken: string): Promise<ReactionExecutionResult> {
+  private async pauseResumePlayback(
+    accessToken: string
+  ): Promise<ReactionExecutionResult> {
     try {
       // First get current playback state
       const stateResponse = await fetch(`${this.apiBaseUrl}/me/player`, {
@@ -181,7 +188,8 @@ export class SpotifyReactionExecutor implements ReactionExecutor {
       if (response.status === 403) {
         return {
           success: false,
-          error: 'No active device found. Please start Spotify on a device first.',
+          error:
+            'No active device found. Please start Spotify on a device first.',
         };
       }
 
@@ -361,7 +369,8 @@ export class SpotifyReactionExecutor implements ReactionExecutor {
       if (response.status === 403) {
         return {
           success: false,
-          error: 'No active device found. Please start Spotify on a device first.',
+          error:
+            'No active device found. Please start Spotify on a device first.',
         };
       }
 
@@ -405,7 +414,11 @@ export class SpotifyReactionExecutor implements ReactionExecutor {
       device_id?: string;
     };
 
-    if (volume_percent === undefined || volume_percent < 0 || volume_percent > 100) {
+    if (
+      volume_percent === undefined ||
+      volume_percent < 0 ||
+      volume_percent > 100
+    ) {
       return {
         success: false,
         error: 'Volume percent must be between 0 and 100',
@@ -446,7 +459,8 @@ export class SpotifyReactionExecutor implements ReactionExecutor {
       if (response.status === 403) {
         return {
           success: false,
-          error: 'No active device found. Please start Spotify on a device first.',
+          error:
+            'No active device found. Please start Spotify on a device first.',
         };
       }
 

--- a/backend/src/services/services/spotify/index.ts
+++ b/backend/src/services/services/spotify/index.ts
@@ -1,6 +1,7 @@
 import type { Service } from '../../../types/service';
 import { spotifyActions } from './actions';
 import { spotifyReactions } from './reactions';
+import { spotifyReactionExecutor } from './executor';
 
 const spotifyService: Service = {
   id: 'spotify',
@@ -17,6 +18,8 @@ const spotifyService: Service = {
 };
 
 export default spotifyService;
+
+export const executor = spotifyReactionExecutor;
 
 export async function initialize(): Promise<void> {
   console.log('Initializing Spotify service...');

--- a/backend/src/services/services/spotify/oauth.ts
+++ b/backend/src/services/services/spotify/oauth.ts
@@ -53,7 +53,7 @@ export class SpotifyOAuth {
       client_id: this.clientId,
       response_type: 'code',
       redirect_uri: this.redirectUri,
-      scope: 'user-read-email user-read-private user-modify-playback-state playlist-modify-public playlist-modify-private user-read-playback-state',
+      scope: 'user-read-email user-read-private user-modify-playback-state playlist-modify-public playlist-modify-private user-read-playback-state user-library-modify',
       state: state,
     });
     return `${this.spotifyAuthBaseUrl}/authorize?${params.toString()}`;

--- a/backend/src/services/services/spotify/oauth.ts
+++ b/backend/src/services/services/spotify/oauth.ts
@@ -53,7 +53,8 @@ export class SpotifyOAuth {
       client_id: this.clientId,
       response_type: 'code',
       redirect_uri: this.redirectUri,
-      scope: 'user-read-email user-read-private user-modify-playback-state playlist-modify-public playlist-modify-private user-read-playback-state user-library-modify',
+      scope:
+        'user-read-email user-read-private user-modify-playback-state playlist-modify-public playlist-modify-private user-read-playback-state user-library-modify',
       state: state,
     });
     return `${this.spotifyAuthBaseUrl}/authorize?${params.toString()}`;

--- a/backend/src/services/services/spotify/oauth.ts
+++ b/backend/src/services/services/spotify/oauth.ts
@@ -53,7 +53,7 @@ export class SpotifyOAuth {
       client_id: this.clientId,
       response_type: 'code',
       redirect_uri: this.redirectUri,
-      scope: 'user-read-email user-read-private',
+      scope: 'user-read-email user-read-private user-modify-playback-state playlist-modify-public playlist-modify-private user-read-playback-state',
       state: state,
     });
     return `${this.spotifyAuthBaseUrl}/authorize?${params.toString()}`;

--- a/backend/src/services/services/spotify/reactions.ts
+++ b/backend/src/services/services/spotify/reactions.ts
@@ -1,5 +1,150 @@
 import type { ReactionDefinition } from '../../../types/service';
+import {
+  spotifySkipTrackSchema,
+  spotifyPauseResumePlaybackSchema,
+  spotifyAddSongToPlaylistSchema,
+  spotifyPlaySpecificTrackSchema,
+  spotifySetVolumeSchema,
+} from './schemas';
 
 // Spotify reactions
-// TODO: Add Spotify reactions
-export const spotifyReactions: ReactionDefinition[] = [];
+export const spotifyReactions: ReactionDefinition[] = [
+  {
+    id: 'spotify.skip_track',
+    name: 'Skip Current Track',
+    description: 'Skips to the next track in the user\'s current playback',
+    configSchema: spotifySkipTrackSchema,
+    outputSchema: {
+      type: 'object',
+      properties: {
+        success: {
+          type: 'boolean',
+          description: 'Whether the skip operation was successful',
+        },
+      },
+      required: ['success'],
+    },
+    metadata: {
+      category: 'Spotify',
+      tags: ['music', 'playback', 'skip'],
+      requiresAuth: true,
+      estimatedDuration: 1000,
+    },
+  },
+  {
+    id: 'spotify.pause_resume_playback',
+    name: 'Pause / Resume Playback',
+    description: 'Toggles playback pause or resume depending on current state',
+    configSchema: spotifyPauseResumePlaybackSchema,
+    outputSchema: {
+      type: 'object',
+      properties: {
+        action: {
+          type: 'string',
+          description: 'The action performed (pause or resume)',
+        },
+        success: {
+          type: 'boolean',
+          description: 'Whether the toggle operation was successful',
+        },
+      },
+      required: ['action', 'success'],
+    },
+    metadata: {
+      category: 'Spotify',
+      tags: ['music', 'playback', 'pause', 'resume'],
+      requiresAuth: true,
+      estimatedDuration: 1000,
+    },
+  },
+  {
+    id: 'spotify.add_song_to_playlist',
+    name: 'Add Song to Playlist',
+    description: 'Adds the current or specified track to a chosen playlist',
+    configSchema: spotifyAddSongToPlaylistSchema,
+    outputSchema: {
+      type: 'object',
+      properties: {
+        playlist_id: {
+          type: 'string',
+          description: 'The ID of the playlist the track was added to',
+        },
+        track_uri: {
+          type: 'string',
+          description: 'The URI of the track that was added',
+        },
+        success: {
+          type: 'boolean',
+          description: 'Whether the add operation was successful',
+        },
+      },
+      required: ['playlist_id', 'track_uri', 'success'],
+    },
+    metadata: {
+      category: 'Spotify',
+      tags: ['music', 'playlist', 'add'],
+      requiresAuth: true,
+      estimatedDuration: 1500,
+    },
+  },
+  {
+    id: 'spotify.play_specific_track',
+    name: 'Play Specific Track',
+    description: 'Starts playback of a given track or playlist URI',
+    configSchema: spotifyPlaySpecificTrackSchema,
+    outputSchema: {
+      type: 'object',
+      properties: {
+        uri: {
+          type: 'string',
+          description: 'The URI that was played',
+        },
+        device_id: {
+          type: 'string',
+          description: 'The device ID used for playback',
+        },
+        success: {
+          type: 'boolean',
+          description: 'Whether the play operation was successful',
+        },
+      },
+      required: ['uri', 'success'],
+    },
+    metadata: {
+      category: 'Spotify',
+      tags: ['music', 'playback', 'play'],
+      requiresAuth: true,
+      estimatedDuration: 1500,
+    },
+  },
+  {
+    id: 'spotify.set_volume',
+    name: 'Set Volume',
+    description: 'Adjusts the playback volume to a specified level',
+    configSchema: spotifySetVolumeSchema,
+    outputSchema: {
+      type: 'object',
+      properties: {
+        volume_percent: {
+          type: 'number',
+          description: 'The volume level that was set',
+        },
+        device_id: {
+          type: 'string',
+          description: 'The device ID the volume was set on',
+        },
+        success: {
+          type: 'boolean',
+          description: 'Whether the volume set operation was successful',
+        },
+      },
+      required: ['volume_percent', 'success'],
+    },
+    metadata: {
+      category: 'Spotify',
+      tags: ['music', 'playback', 'volume'],
+      requiresAuth: true,
+      estimatedDuration: 1000,
+    },
+  },
+];

--- a/backend/src/services/services/spotify/reactions.ts
+++ b/backend/src/services/services/spotify/reactions.ts
@@ -12,7 +12,7 @@ export const spotifyReactions: ReactionDefinition[] = [
   {
     id: 'spotify.skip_track',
     name: 'Skip Current Track',
-    description: 'Skips to the next track in the user\'s current playback',
+    description: "Skips to the next track in the user's current playback",
     configSchema: spotifySkipTrackSchema,
     outputSchema: {
       type: 'object',
@@ -60,14 +60,16 @@ export const spotifyReactions: ReactionDefinition[] = [
   {
     id: 'spotify.add_song_to_playlist',
     name: 'Add Song to Playlist',
-    description: 'Adds the current or specified track to a chosen playlist (or to Liked Songs if no playlist specified)',
+    description:
+      'Adds the current or specified track to a chosen playlist (or to Liked Songs if no playlist specified)',
     configSchema: spotifyAddSongToPlaylistSchema,
     outputSchema: {
       type: 'object',
       properties: {
         playlist_id: {
           type: 'string',
-          description: 'The ID of the playlist the track was added to (null if added to Liked Songs)',
+          description:
+            'The ID of the playlist the track was added to (null if added to Liked Songs)',
         },
         added_to_liked: {
           type: 'boolean',

--- a/backend/src/services/services/spotify/reactions.ts
+++ b/backend/src/services/services/spotify/reactions.ts
@@ -60,14 +60,18 @@ export const spotifyReactions: ReactionDefinition[] = [
   {
     id: 'spotify.add_song_to_playlist',
     name: 'Add Song to Playlist',
-    description: 'Adds the current or specified track to a chosen playlist',
+    description: 'Adds the current or specified track to a chosen playlist (or to Liked Songs if no playlist specified)',
     configSchema: spotifyAddSongToPlaylistSchema,
     outputSchema: {
       type: 'object',
       properties: {
         playlist_id: {
           type: 'string',
-          description: 'The ID of the playlist the track was added to',
+          description: 'The ID of the playlist the track was added to (null if added to Liked Songs)',
+        },
+        added_to_liked: {
+          type: 'boolean',
+          description: 'Whether the track was added to Liked Songs',
         },
         track_uri: {
           type: 'string',
@@ -78,7 +82,7 @@ export const spotifyReactions: ReactionDefinition[] = [
           description: 'Whether the add operation was successful',
         },
       },
-      required: ['playlist_id', 'track_uri', 'success'],
+      required: ['added_to_liked', 'track_uri', 'success'],
     },
     metadata: {
       category: 'Spotify',

--- a/backend/src/services/services/spotify/schemas.ts
+++ b/backend/src/services/services/spotify/schemas.ts
@@ -15,13 +15,13 @@ export const spotifyPauseResumePlaybackSchema: ActionReactionSchema = {
 
 export const spotifyAddSongToPlaylistSchema: ActionReactionSchema = {
   name: 'Add Song to Playlist',
-  description: 'Adds the current or specified track to a chosen playlist',
+  description: 'Adds the current or specified track to a chosen playlist (or to Liked Songs if no playlist specified)',
   fields: [
     {
       name: 'playlist_id',
       type: 'text',
-      label: 'Playlist ID',
-      required: true,
+      label: 'Playlist ID (optional, adds to Liked Songs if empty)',
+      required: false,
       placeholder: 'spotify:playlist:37i9dQZF1DXcBWIGoYBM5M',
     },
     {

--- a/backend/src/services/services/spotify/schemas.ts
+++ b/backend/src/services/services/spotify/schemas.ts
@@ -3,7 +3,7 @@ import type { ActionReactionSchema } from '../../../types/mapping';
 
 export const spotifySkipTrackSchema: ActionReactionSchema = {
   name: 'Skip Current Track',
-  description: 'Skips to the next track in the user\'s current playback',
+  description: "Skips to the next track in the user's current playback",
   fields: [],
 };
 
@@ -15,7 +15,8 @@ export const spotifyPauseResumePlaybackSchema: ActionReactionSchema = {
 
 export const spotifyAddSongToPlaylistSchema: ActionReactionSchema = {
   name: 'Add Song to Playlist',
-  description: 'Adds the current or specified track to a chosen playlist (or to Liked Songs if no playlist specified)',
+  description:
+    'Adds the current or specified track to a chosen playlist (or to Liked Songs if no playlist specified)',
   fields: [
     {
       name: 'playlist_id',

--- a/backend/src/services/services/spotify/schemas.ts
+++ b/backend/src/services/services/spotify/schemas.ts
@@ -1,2 +1,77 @@
 // Spotify service schemas
-// TODO: Add Spotify action and reaction schemas here
+import type { ActionReactionSchema } from '../../../types/mapping';
+
+export const spotifySkipTrackSchema: ActionReactionSchema = {
+  name: 'Skip Current Track',
+  description: 'Skips to the next track in the user\'s current playback',
+  fields: [],
+};
+
+export const spotifyPauseResumePlaybackSchema: ActionReactionSchema = {
+  name: 'Pause / Resume Playback',
+  description: 'Toggles playback pause or resume depending on current state',
+  fields: [],
+};
+
+export const spotifyAddSongToPlaylistSchema: ActionReactionSchema = {
+  name: 'Add Song to Playlist',
+  description: 'Adds the current or specified track to a chosen playlist',
+  fields: [
+    {
+      name: 'playlist_id',
+      type: 'text',
+      label: 'Playlist ID',
+      required: true,
+      placeholder: 'spotify:playlist:37i9dQZF1DXcBWIGoYBM5M',
+    },
+    {
+      name: 'track_uri',
+      type: 'text',
+      label: 'Track URI (optional, uses currently playing track if empty)',
+      required: false,
+      placeholder: 'spotify:track:4iV5W9uYEdYUVa79Axb7Rh',
+    },
+  ],
+};
+
+export const spotifyPlaySpecificTrackSchema: ActionReactionSchema = {
+  name: 'Play Specific Track',
+  description: 'Starts playback of a given track or playlist URI',
+  fields: [
+    {
+      name: 'uri',
+      type: 'text',
+      label: 'Spotify URI (track, album, playlist, or artist)',
+      required: true,
+      placeholder: 'spotify:track:4iV5W9uYEdYUVa79Axb7Rh',
+    },
+    {
+      name: 'device_id',
+      type: 'text',
+      label: 'Device ID (optional, uses active device if empty)',
+      required: false,
+      placeholder: 'device_id_here',
+    },
+  ],
+};
+
+export const spotifySetVolumeSchema: ActionReactionSchema = {
+  name: 'Set Volume',
+  description: 'Adjusts the playback volume to a specified level',
+  fields: [
+    {
+      name: 'volume_percent',
+      type: 'number',
+      label: 'Volume Level (0-100)',
+      required: true,
+      placeholder: '50',
+    },
+    {
+      name: 'device_id',
+      type: 'text',
+      label: 'Device ID (optional, uses active device if empty)',
+      required: false,
+      placeholder: 'device_id_here',
+    },
+  ],
+};


### PR DESCRIPTION
This pull request significantly expands Spotify integration in the backend by adding new reaction capabilities, updating OAuth scopes to support these features, and defining schemas for configuration and output. The changes enable actions such as skipping tracks, pausing/resuming playback, adding songs to playlists, playing specific tracks, and setting volume—all through the backend service.

**Spotify reaction support:**

* Implemented five new Spotify reactions: skip track, pause/resume playback, add song to playlist, play specific track, and set volume, each with detailed configuration and output schemas in `reactions.ts` and `schemas.ts`. [[1]](diffhunk://#diff-c42b781a17b7630b2dc708354e4498cf6c4dfbc28b87c3d05ef0d0d114030411R2-R156) [[2]](diffhunk://#diff-71724d29765dea91255c6563477ecf14870bbf16fcf6a81387015d23737474d0L2-R78)

**OAuth scope and authentication updates:**

* Updated Spotify OAuth scopes everywhere in the backend to include permissions required for playback control and playlist modification, ensuring all new reactions are supported. [[1]](diffhunk://#diff-25c35c799a1700794d71dc5369f3ab64bf6f2f63693ec819cfa051a24413124fL453-R461) [[2]](diffhunk://#diff-9879bb9aa4328ab021eb15caac21b7361df745cbf63a2a03bca55fe96ae1986bL56-R57)
* Adjusted token handling to dynamically use the scope returned by Spotify, improving reliability of authentication and authorization.
* Removed redundant scope specification in the Spotify authentication route, relying on the updated configuration.

**Service structure improvements:**

* Exported the Spotify reaction executor from `index.ts` for use elsewhere in the backend, supporting the new reaction implementations. [[1]](diffhunk://#diff-1ab10d893323e80218dc61cfbe628df88f55be2099400ac599cde8adaf923a83R4) [[2]](diffhunk://#diff-1ab10d893323e80218dc61cfbe628df88f55be2099400ac599cde8adaf923a83R22-R23)