### PR TITLE
fix(ci): refine conditions for build-and-push, push-to-mirror, and de…

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -257,7 +257,7 @@ jobs:
   build-and-push:
     needs: [backend-test, web-linter, mobile-test]
     name: Build and Push Docker Images
-    if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.base_ref == 'main') || (github.event_name == 'push' && contains(github.event.head_commit.message, 'Merge pull request') && github.base_ref == 'main') }}
+    if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.merged == true) || (github.event_name == 'push' && contains(github.event.head_commit.message, 'Merge pull request')) }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -322,7 +322,7 @@ jobs:
   push-to-mirror:
     name: Push to Mirror Repository
     needs: deploy-app
-    if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.merged == true) || (github.event_name == 'push' && contains(github.event.head_commit.message, 'Merge pull request')) }}
+    if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.ref == 'refs/heads/main') || (github.event_name == 'push' && contains(github.event.head_commit.message, 'Merge pull request') && github.ref == 'refs/heads/main') }}
     environment: PIPELINE
     runs-on: ubuntu-latest
     steps:
@@ -359,7 +359,7 @@ jobs:
     name: Deploy in production server
     runs-on: ubuntu-latest
     needs: deploy-app
-    if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.base_ref == 'main') || (github.event_name == 'push' && contains(github.event.head_commit.message, 'Merge pull request') && github.base_ref == 'main') }}
+    if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.ref == 'refs/heads/main') || (github.event_name == 'push' && contains(github.event.head_commit.message, 'Merge pull request') && github.ref == 'refs/heads/main') }}
     environment: PIPELINE
     steps:
       - name: Execute remote SSH commands using password


### PR DESCRIPTION
This pull request updates conditional logic in the `.github/workflows/cicd.yml` workflow file to better control when certain CI/CD jobs are executed. The changes primarily affect how jobs are triggered based on the branch reference, ensuring that critical actions like deploying and pushing to mirrors only occur on the `main` branch.

Conditional logic improvements for job execution:

* Updated the `build-and-push` job to remove the requirement for `github.base_ref == 'main'`, allowing it to run for merged pull requests and relevant pushes regardless of base branch.
* Modified the `push-to-mirror` job to add a strict check for `github.ref == 'refs/heads/main'`, ensuring this job only runs on the `main` branch for both merged pull requests and pushes.
* Changed the production deployment job to also require `github.ref == 'refs/heads/main'`, so deployment only happens when changes land on the `main` branch.…ploy jobs to ensure proper branch checks