### PR TITLE
is_mobile parameter in redirections

### DIFF
--- a/backend/src/routes/services/subscription.ts
+++ b/backend/src/routes/services/subscription.ts
@@ -286,8 +286,17 @@ async function handleDynamicServiceSubscription(
  */
 router.get(
   '/:service/subscribe',
+  (req, res, next) => {
+    if (req.query.is_mobile === 'true') {
+      const session = req.session as {
+        is_mobile?: boolean;
+      } & typeof req.session;
+      session.is_mobile = true;
+    }
+    next();
+  },
   token,
-  async (req: Request, res: Response, next) => {
+  async (req, res, next) => {
     if (!req.auth) {
       await createLog(
         401,


### PR DESCRIPTION
This pull request enhances the OAuth and service subscription flows to better support mobile clients by introducing a mobile-specific redirect mechanism. The backend now recognizes an `is_mobile` query parameter, manages session state to distinguish mobile requests, and redirects users to deep links or external browsers as appropriate. Documentation has also been updated to guide mobile app developers on the new flow.

**Backend support for mobile OAuth and subscription flows:**

* Added support for the `is_mobile` query parameter in GitHub, Google, and service subscription routes. This sets a session flag to identify mobile-originated requests. [[1]](diffhunk://#diff-278b414c47d2934820f3d227a5faa32d485d5e46baa854fe8317b38ee9f5609fR515-R540) [[2]](diffhunk://#diff-278b414c47d2934820f3d227a5faa32d485d5e46baa854fe8317b38ee9f5609fR713-R719) [[3]](diffhunk://#diff-278b414c47d2934820f3d227a5faa32d485d5e46baa854fe8317b38ee9f5609fR728-R736) [[4]](diffhunk://#diff-d581ceb6f4229e042e0859ff4accde34b0783edef4d5f713434c588269033d64R289-R299)
* Updated OAuth and subscription callback handlers to detect the mobile session flag and redirect users to a deep link (e.g., `mobileApp://callback?...`) or external browser for app installation, instead of the standard web frontend. The session flag is cleared after use to prevent unintended redirects. [[1]](diffhunk://#diff-278b414c47d2934820f3d227a5faa32d485d5e46baa854fe8317b38ee9f5609fR640-R683) [[2]](diffhunk://#diff-278b414c47d2934820f3d227a5faa32d485d5e46baa854fe8317b38ee9f5609fR832-R842) [[3]](diffhunk://#diff-278b414c47d2934820f3d227a5faa32d485d5e46baa854fe8317b38ee9f5609fR926-R938)

**Documentation updates for mobile developers:**

* Revised the service subscription flow documentation to describe the new mobile flow, including how to use the `is_mobile` parameter, handle deep links, and manage external browser redirects for services like GitHub that require app installation.