### PR TITLE
fix (slack): user id issue

### DIFF
--- a/backend/src/services/services/slack/executor.ts
+++ b/backend/src/services/services/slack/executor.ts
@@ -83,8 +83,8 @@ export class SlackReactionExecutor implements ReactionExecutor {
   async execute(
     context: ReactionExecutionContext
   ): Promise<ReactionExecutionResult> {
-    const { reaction, event } = context;
-    const userId = event.user_id;
+    const { reaction, mapping } = context;
+    const userId = mapping.created_by;
 
     try {
       let userToken = await slackOAuth.getUserAccessToken(userId);


### PR DESCRIPTION
This pull request updates the logic for retrieving the user ID in the Slack reaction executor to ensure it uses the correct source of user information. Instead of extracting the user ID from the event, it now obtains it from the reaction mapping, which likely improves reliability and correctness in user identification.

Improvements to user identification:

* Changed the source of `userId` in the `SlackReactionExecutor.execute` method to use `mapping.created_by` instead of `event.user_id`, ensuring the correct user is referenced when executing reactions.