### PR TITLE
Implemented the payload dynamic fields on mobile

### DIFF
--- a/mobile/lib/models/action_models.dart
+++ b/mobile/lib/models/action_models.dart
@@ -7,6 +7,7 @@ class ConfigField {
   final List<ConfigOption>? options;
   final dynamic defaultValue;
   final String? description;
+  final bool isDynamic;
 
   ConfigField({
     required this.name,
@@ -17,6 +18,7 @@ class ConfigField {
     this.options,
     this.defaultValue,
     this.description,
+    this.isDynamic = false,
   });
 
   factory ConfigField.fromJson(Map<String, dynamic> json) {
@@ -31,6 +33,7 @@ class ConfigField {
           : null,
       defaultValue: json['default'],
       description: json['description'] as String?,
+      isDynamic: json['dynamic'] as bool? ?? false,
     );
   }
 
@@ -44,6 +47,7 @@ class ConfigField {
       'options': options?.map((option) => option.toJson()).toList(),
       'default': defaultValue,
       'description': description,
+      'dynamic': isDynamic,
     };
   }
 
@@ -194,12 +198,40 @@ class ActionMetadata {
   }
 }
 
+class PayloadField {
+  final String path;
+  final String type;
+  final String description;
+  final String? example;
+
+  PayloadField({
+    required this.path,
+    required this.type,
+    required this.description,
+    this.example,
+  });
+
+  factory PayloadField.fromJson(Map<String, dynamic> json) {
+    return PayloadField(
+      path: json['path'] as String,
+      type: json['type'] as String,
+      description: json['description'] as String,
+      example: json['example'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {'path': path, 'type': type, 'description': description, 'example': example};
+  }
+}
+
 class ActionModel {
   final String id;
   final String name;
   final String description;
   final ConfigSchema? configSchema;
   final Map<String, dynamic>? inputSchema;
+  final List<PayloadField>? payloadFields;
   final ActionMetadata? metadata;
 
   ActionModel({
@@ -208,6 +240,7 @@ class ActionModel {
     required this.description,
     this.configSchema,
     this.inputSchema,
+    this.payloadFields,
     this.metadata,
   });
 
@@ -220,6 +253,11 @@ class ActionModel {
           ? ConfigSchema.fromJson(json['configSchema'])
           : null,
       inputSchema: json['inputSchema'] as Map<String, dynamic>?,
+      payloadFields: json['payloadFields'] != null
+          ? (json['payloadFields'] as List)
+                .map((field) => PayloadField.fromJson(field))
+                .toList()
+          : null,
       metadata: json['metadata'] != null ? ActionMetadata.fromJson(json['metadata']) : null,
     );
   }
@@ -231,6 +269,7 @@ class ActionModel {
       'description': description,
       'configSchema': configSchema?.toJson(),
       'inputSchema': inputSchema,
+      'payloadFields': payloadFields?.map((field) => field.toJson()).toList(),
       'metadata': metadata?.toJson(),
     };
   }

--- a/mobile/lib/widgets/dynamic_text_field.dart
+++ b/mobile/lib/widgets/dynamic_text_field.dart
@@ -1,0 +1,286 @@
+import 'package:flutter/material.dart';
+import 'package:area/models/action_models.dart';
+import 'package:area/core/constants/app_colors.dart';
+
+class DynamicTextField extends StatefulWidget {
+  final String? label;
+  final String? placeholder;
+  final bool required;
+  final String? initialValue;
+  final Function(String) onChanged;
+  final List<PayloadField> payloadFields;
+  final int maxLines;
+  final String? Function(String?)? validator;
+  final TextEditingController? controller;
+
+  const DynamicTextField({
+    super.key,
+    this.label,
+    this.placeholder,
+    this.required = false,
+    this.initialValue,
+    required this.onChanged,
+    this.payloadFields = const [],
+    this.maxLines = 1,
+    this.validator,
+    this.controller,
+  });
+
+  @override
+  State<DynamicTextField> createState() => _DynamicTextFieldState();
+}
+
+class _DynamicTextFieldState extends State<DynamicTextField> {
+  late TextEditingController _controller;
+  final FocusNode _focusNode = FocusNode();
+  final LayerLink _layerLink = LayerLink();
+  OverlayEntry? _overlayEntry;
+
+  List<PayloadField> _filteredSuggestions = [];
+  int _selectedIndex = -1;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = widget.controller ?? TextEditingController(text: widget.initialValue);
+    _focusNode.addListener(_onFocusChange);
+  }
+
+  @override
+  void dispose() {
+    _removeOverlay();
+    _focusNode.removeListener(_onFocusChange);
+    _focusNode.dispose();
+    if (widget.controller == null) {
+      _controller.dispose();
+    }
+    super.dispose();
+  }
+
+  void _onFocusChange() {
+    if (!_focusNode.hasFocus) {
+      _hideOverlay();
+    }
+  }
+
+  void _onTextChanged(String text) {
+    widget.onChanged(text);
+
+    final cursorPosition = _controller.selection.baseOffset;
+    if (cursorPosition < 0) return;
+
+    final textBeforeCursor = text.substring(0, cursorPosition);
+    final lastOpenBrace = textBeforeCursor.lastIndexOf('{');
+
+    if (lastOpenBrace != -1 && lastOpenBrace == cursorPosition - 1) {
+      _filteredSuggestions = widget.payloadFields;
+      _selectedIndex = -1;
+      _showOverlay();
+    } else {
+      _hideOverlay();
+    }
+  }
+
+  void _showOverlay() {
+    if (_filteredSuggestions.isEmpty) return;
+
+    _removeOverlay();
+
+    _overlayEntry = _createOverlayEntry();
+    Overlay.of(context).insert(_overlayEntry!);
+  }
+
+  void _hideOverlay() {
+    _removeOverlay();
+    setState(() {
+      _selectedIndex = -1;
+    });
+  }
+
+  void _removeOverlay() {
+    _overlayEntry?.remove();
+    _overlayEntry = null;
+  }
+
+  OverlayEntry _createOverlayEntry() {
+    final renderBox = context.findRenderObject() as RenderBox;
+    final size = renderBox.size;
+
+    return OverlayEntry(
+      builder: (context) => Positioned(
+        width: size.width,
+        child: CompositedTransformFollower(
+          link: _layerLink,
+          showWhenUnlinked: false,
+          offset: Offset(0, size.height + 4),
+          child: Material(
+            elevation: 8,
+            borderRadius: BorderRadius.circular(8),
+            child: Container(
+              constraints: const BoxConstraints(maxHeight: 200),
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: Colors.grey.shade300),
+              ),
+              child: ListView.builder(
+                padding: EdgeInsets.zero,
+                shrinkWrap: true,
+                itemCount: _filteredSuggestions.length,
+                itemBuilder: (context, index) {
+                  final field = _filteredSuggestions[index];
+                  final isSelected = index == _selectedIndex;
+
+                  return InkWell(
+                    onTap: () => _insertSuggestion(field),
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                      decoration: BoxDecoration(
+                        color: isSelected
+                            ? AppColors.areaBlue3.withValues(alpha: 0.1)
+                            : Colors.transparent,
+                        border: Border(
+                          bottom: BorderSide(
+                            color: index < _filteredSuggestions.length - 1
+                                ? Colors.grey.shade200
+                                : Colors.transparent,
+                          ),
+                        ),
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            '{{action.payload.${field.path}}}',
+                            style: TextStyle(
+                              fontFamily: 'monospace',
+                              fontSize: 12,
+                              color: AppColors.areaBlue3,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            field.description,
+                            style: TextStyle(fontSize: 11, color: Colors.grey.shade600),
+                          ),
+                          if (field.example != null) ...[
+                            const SizedBox(height: 2),
+                            Text(
+                              'Example: ${field.example}',
+                              style: TextStyle(
+                                fontSize: 10,
+                                color: Colors.grey.shade500,
+                                fontStyle: FontStyle.italic,
+                              ),
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _insertSuggestion(PayloadField field) {
+    final currentCursorPos = _controller.selection.baseOffset;
+    final text = _controller.text;
+    final textBeforeCursor = text.substring(0, currentCursorPos);
+    final lastOpenBrace = textBeforeCursor.lastIndexOf('{');
+
+    if (lastOpenBrace != -1 && lastOpenBrace == currentCursorPos - 1) {
+      final beforeBrace = text.substring(0, lastOpenBrace);
+      final afterBrace = text.substring(currentCursorPos);
+      final template = '{{action.payload.${field.path}}}';
+      final newText = '$beforeBrace$template$afterBrace';
+
+      _controller.value = TextEditingValue(
+        text: newText,
+        selection: TextSelection.collapsed(offset: beforeBrace.length + template.length),
+      );
+
+      widget.onChanged(newText);
+      _hideOverlay();
+
+      _focusNode.requestFocus();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return CompositedTransformTarget(
+      link: _layerLink,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (widget.label != null) ...[
+            RichText(
+              text: TextSpan(
+                style: const TextStyle(
+                  color: Colors.black87,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w500,
+                ),
+                children: [
+                  TextSpan(text: widget.label),
+                  if (widget.required)
+                    const TextSpan(
+                      text: ' *',
+                      style: TextStyle(color: Colors.red),
+                    ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 8),
+          ],
+          if (widget.payloadFields.isNotEmpty)
+            Container(
+              padding: const EdgeInsets.all(8),
+              margin: const EdgeInsets.only(bottom: 8),
+              decoration: BoxDecoration(
+                color: AppColors.areaBlue3.withValues(alpha: 0.1),
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: AppColors.areaBlue3.withValues(alpha: 0.3)),
+              ),
+              child: Row(
+                children: [
+                  Icon(Icons.lightbulb_outline, size: 16, color: AppColors.areaBlue3),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      'Type { to see action data suggestions',
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: AppColors.areaBlue3,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          TextFormField(
+            controller: _controller,
+            focusNode: _focusNode,
+            maxLines: widget.maxLines,
+            style: const TextStyle(fontFamily: 'monospace', fontSize: 14),
+            decoration: InputDecoration(
+              hintText: widget.placeholder,
+              border: const OutlineInputBorder(),
+              filled: true,
+              fillColor: AppColors.areaBlue3.withValues(alpha: 0.05),
+            ),
+            validator: widget.validator,
+            onChanged: _onTextChanged,
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This pull request introduces support for dynamic text fields that allow users to insert action payload data into configuration fields using an autocomplete overlay. The main changes include extending the data models to support dynamic fields and payload metadata, updating the automation configuration screen to use these new capabilities, and adding a new reusable widget for dynamic text entry with suggestions.

**Dynamic field and payload support in models:**

* Added an `isDynamic` boolean property to the `ConfigField` model, with serialization and deserialization support, to indicate fields that support dynamic payload insertion. [[1]](diffhunk://#diff-35822858b6fc9b301f91d2af25bc0472757794a1291a15ce04517e8209467cf2R10) [[2]](diffhunk://#diff-35822858b6fc9b301f91d2af25bc0472757794a1291a15ce04517e8209467cf2R21) [[3]](diffhunk://#diff-35822858b6fc9b301f91d2af25bc0472757794a1291a15ce04517e8209467cf2R36) [[4]](diffhunk://#diff-35822858b6fc9b301f91d2af25bc0472757794a1291a15ce04517e8209467cf2R50)
* Introduced a new `PayloadField` model to describe available payload data, and updated the `ActionModel` to include an optional list of these fields, with full serialization and deserialization support. [[1]](diffhunk://#diff-35822858b6fc9b301f91d2af25bc0472757794a1291a15ce04517e8209467cf2R201-R234) [[2]](diffhunk://#diff-35822858b6fc9b301f91d2af25bc0472757794a1291a15ce04517e8209467cf2R243) [[3]](diffhunk://#diff-35822858b6fc9b301f91d2af25bc0472757794a1291a15ce04517e8209467cf2R256-R260) [[4]](diffhunk://#diff-35822858b6fc9b301f91d2af25bc0472757794a1291a15ce04517e8209467cf2R272)

**UI and widget enhancements:**

* Added a new `DynamicTextField` widget that provides autocomplete suggestions for payload fields when the user types `{` in a dynamic text field. The widget manages overlay display, suggestion filtering, and template insertion.
* Updated the automation configuration screen to use the new dynamic text field for fields marked as dynamic, passing available payload fields for suggestions. [[1]](diffhunk://#diff-9be9930c1d7c3dc765ee0bc8352db6cc50c975af5bcaa9f8918faf007eb04868R9) [[2]](diffhunk://#diff-9be9930c1d7c3dc765ee0bc8352db6cc50c975af5bcaa9f8918faf007eb04868R62-R73) [[3]](diffhunk://#diff-9be9930c1d7c3dc765ee0bc8352db6cc50c975af5bcaa9f8918faf007eb04868R96-R128) [[4]](diffhunk://#diff-9be9930c1d7c3dc765ee0bc8352db6cc50c975af5bcaa9f8918faf007eb04868R416) [[5]](diffhunk://#diff-9be9930c1d7c3dc765ee0bc8352db6cc50c975af5bcaa9f8918faf007eb04868R466)