### PR TITLE
fix (CI/CD): Update the ci cd so it works

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -233,7 +233,6 @@ jobs:
           SERVICE_GITHUB_CLIENT_SECRET: ${{ secrets.SERVICE_GITHUB_CLIENT_SECRET }}
           SERVICE_GITHUB_REDIRECT_URI: ${{ secrets.SERVICE_GITHUB_REDIRECT_URI }}
 
-
         run: |
           echo "DB_USER=$DB_USER" > ./deployment/.env
           echo "DB_PASSWORD=$DB_PASSWORD" >> ./deployment/.env
@@ -247,7 +246,6 @@ jobs:
           echo "SERVICE_GITHUB_CLIENT_ID=$SERVICE_GITHUB_CLIENT_ID" >> ./deployment/.env
           echo "SERVICE_GITHUB_CLIENT_SECRET=$SERVICE_GITHUB_CLIENT_SECRET" >> ./deployment/.env
           echo "SERVICE_GITHUB_REDIRECT_URI=$SERVICE_GITHUB_REDIRECT_URI" >> ./deployment/.env
-
 
       - name: Clean all containers
         run: docker compose -f ./deployment/docker-compose.yml down -v
@@ -314,12 +312,16 @@ jobs:
 
       - name: Build and push Docker image
         env:
-          FRONTEND_URL: "http://localhost:8081"
+          FRONTEND_URL: "https://frontend.nduboi.fr"
+          BACKEND_URL: "https://backend.nduboi.fr"
+          MOBILE_CALLBACK_URL: "mobileapp://callback"
         if: steps.check_dockerfile.outputs.dockerfile_exists == 'true'
         uses: docker/build-push-action@v5
         with:
           build-args: |
             FRONTEND_URL=${FRONTEND_URL}
+            BACKEND_URL=${BACKEND_URL}
+            MOBILE_CALLBACK_URL=${MOBILE_CALLBACK_URL}
           file: ./deployment/Dockerfile.${{ matrix.component }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/cicd.yml` workflow to improve how environment variables are managed for deployment and Docker builds. The main changes involve removing secret-based population of certain URLs in the `.env` file and instead setting them explicitly during the Docker image build process.

**Environment variable management:**

* Removed population of `BACKEND_URL` and `MOBILE_CALLBACK_URL` from GitHub secrets in the environment and from the generated `.env` file during the workflow setup. [[1]](diffhunk://#diff-6727e33ccc9195d67f0786e1384f8f1cdaf4090c3e77547943105bd2b28c99d0L235-R235) [[2]](diffhunk://#diff-6727e33ccc9195d67f0786e1384f8f1cdaf4090c3e77547943105bd2b28c99d0L250-L252)

**Docker build configuration:**

* Set `FRONTEND_URL`, `BACKEND_URL`, and `MOBILE_CALLBACK_URL` to explicit production values in the Docker build environment, and passed them as build arguments to the Dockerfile.