### PR TITLE
fix (spotify): catch errors

### DIFF
--- a/backend/src/services/services/spotify/executor.ts
+++ b/backend/src/services/services/spotify/executor.ts
@@ -150,7 +150,15 @@ export class SpotifyReactionExecutor implements ReactionExecutor {
         };
       }
 
-      const playbackState: SpotifyPlaybackState = await stateResponse.json();
+      let playbackState: SpotifyPlaybackState;
+      try {
+        playbackState = await stateResponse.json();
+      } catch {
+        return {
+          success: false,
+          error: `Failed to parse playback state response: Invalid JSON response from Spotify API`,
+        };
+      }
       const isPlaying = playbackState.is_playing;
 
       // Toggle playback
@@ -234,7 +242,16 @@ export class SpotifyReactionExecutor implements ReactionExecutor {
           };
         }
 
-        const playbackState: SpotifyPlaybackState = await stateResponse.json();
+        let playbackState: SpotifyPlaybackState;
+        try {
+          playbackState = await stateResponse.json();
+        } catch {
+          return {
+            success: false,
+            error:
+              'Failed to parse playback state response: Invalid JSON response from Spotify API',
+          };
+        }
         if (!playbackState.item?.uri) {
           return {
             success: false,


### PR DESCRIPTION
This pull request improves error handling in the `SpotifyReactionExecutor` by adding checks for invalid JSON responses from the Spotify API. Now, if the API returns malformed JSON, the executor will return a clear error instead of throwing an unhandled exception.

Error handling improvements:

* Wrapped `stateResponse.json()` calls in `try/catch` blocks to handle invalid JSON responses gracefully, returning a descriptive error if parsing fails. (`backend/src/services/services/spotify/executor.ts`) [[1]](diffhunk://#diff-6670c06b75790b6c7b3fab164531179dc918e249ea3b5fe290bcdbadd8ae95feL153-R161) [[2]](diffhunk://#diff-6670c06b75790b6c7b3fab164531179dc918e249ea3b5fe290bcdbadd8ae95feL237-R254)