### PR TITLE
Fix timer action route

### DIFF
--- a/backend/src/routes/services/index.ts
+++ b/backend/src/routes/services/index.ts
@@ -791,7 +791,6 @@ router.get(
         .filter(subscription => subscription.subscribed)
         .map(subscription => subscription.service);
 
-      // Include services that are always subscribed
       const alwaysSubscribedServiceIds = serviceRegistry
         .getAllServices()
         .filter(service => service.alwaysSubscribed)


### PR DESCRIPTION
This pull request updates the logic for determining which services are considered "subscribed" in the `backend/src/routes/services/index.ts` file. The main change is that services marked as `alwaysSubscribed` are now always included in the list of subscribed services, regardless of user subscription status.

Key changes:

**Subscription logic improvements:**

* Added logic to collect all service IDs with the `alwaysSubscribed` flag and ensure they are always included in the list of subscribed services (`allSubscribedServiceIds`). [[1]](diffhunk://#diff-c854ecfb8a1ce95e3689a144016021605424309ba28da9d02f010623dbbc82e7R679-R692) [[2]](diffhunk://#diff-c854ecfb8a1ce95e3689a144016021605424309ba28da9d02f010623dbbc82e7R794-R807)
* Updated the filtering of services to use `allSubscribedServiceIds` instead of just user-subscribed IDs, so that "always subscribed" services are returned even if the user hasn't explicitly subscribed. [[1]](diffhunk://#diff-c854ecfb8a1ce95e3689a144016021605424309ba28da9d02f010623dbbc82e7R679-R692) [[2]](diffhunk://#diff-c854ecfb8a1ce95e3689a144016021605424309ba28da9d02f010623dbbc82e7R794-R807)