### PR TITLE
fix (docker): update Flutter version to 3.35.6 and add precache step

### DIFF
--- a/deployment/Dockerfile.mobile
+++ b/deployment/Dockerfile.mobile
@@ -1,5 +1,5 @@
 # Flutter Mobile Build Dockerfile
-FROM ghcr.io/cirruslabs/flutter:3.35.4 AS builder
+FROM ghcr.io/cirruslabs/flutter:3.35.6 AS builder
 
 ARG SKIP_APK_BUILD=false
 ARG FRONTEND_URL
@@ -19,6 +19,8 @@ RUN if [ -z "$FRONTEND_URL" ]; \
 WORKDIR /app
 
 COPY mobile/ ./
+
+RUN flutter precache --android
 
 RUN flutter clean
 

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -9,7 +9,7 @@ version: 1.0.0+1
 
 environment:
   sdk: ^3.9.2
-  flutter: 3.35.4
+  flutter: 3.35.6
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION
This pull request updates the Flutter version used in the mobile build environment to 3.35.6 and ensures that Android build dependencies are pre-cached during the Docker build process. These changes help maintain compatibility with the latest Flutter features and improve build reliability.

**Flutter version updates:**

* Updated the base Flutter image in `deployment/Dockerfile.mobile` from version 3.35.4 to 3.35.6.
* Updated the Flutter SDK version constraint in `mobile/pubspec.yaml` from 3.35.4 to 3.35.6.

**Build process improvements:**

* Added a `flutter precache --android` step in `deployment/Dockerfile.mobile` to ensure Android dependencies are available before building.