### PR TITLE
fix (deployment): updated the service on the raspberry, and updated the ci/cd

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -405,4 +405,4 @@ jobs:
           username: ${{ secrets.SSH_USERNAME }}
           password: ${{ secrets.SSH_PASSWORD }}
           port: ${{ secrets.SSH_PORT }}
-          script: bash -i -c "systemctl --user restart deploy.service "
+          script: bash -i -c "sudo systemctl restart deploy.service"


### PR DESCRIPTION
This pull request includes a small change to the deployment step in the CI/CD workflow. The update changes the command used to restart the `deploy.service` to use `sudo` instead of running it as a user service.