### PR TITLE
fix (cd): deploy to raspberry only when the images are built, so that the mobile image gets built, and available

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -396,7 +396,7 @@ jobs:
   build:
     name: Deploy in production server
     runs-on: ubuntu-latest
-    needs: deploy-app
+    needs: [deploy-app, build-and-push]
     if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.ref == 'refs/heads/main') || (github.event_name == 'push' && contains(github.event.head_commit.message, 'Merge pull request') && github.ref == 'refs/heads/main') }}
     environment: PIPELINE
     steps:


### PR DESCRIPTION
This pull request updates the CI/CD workflow to improve deployment reliability by ensuring that the `build` job depends on both the `deploy-app` and `build-and-push` jobs before running.

Workflow dependency update:

* [`.github/workflows/cicd.yml`](diffhunk://#diff-6727e33ccc9195d67f0786e1384f8f1cdaf4090c3e77547943105bd2b28c99d0L399-R399): Modified the `build` job to require both `deploy-app` and `build-and-push` jobs to complete before it runs, instead of only `deploy-app`.