### PR TITLE
fix (ci/cd): passed mobile build args directly via secrets

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -334,17 +334,13 @@ jobs:
             type=ref,event=tag
 
       - name: Build and push Docker image
-        env:
-          FRONTEND_URL: ${{ secrets.FRONTEND_URL }}
-          BACKEND_URL: ${{ secrets.BACKEND_URL }}
-          MOBILE_CALLBACK_URL: ${{ secrets.MOBILE_CALLBACK_URL }}
         if: steps.check_dockerfile.outputs.dockerfile_exists == 'true'
         uses: docker/build-push-action@v5
         with:
           build-args: |
-            FRONTEND_URL=${FRONTEND_URL}
-            BACKEND_URL=${BACKEND_URL}
-            MOBILE_CALLBACK_URL=${MOBILE_CALLBACK_URL}
+            FRONTEND_URL=${{ secrets.FRONTEND_URL }}
+            BACKEND_URL=${{ secrets.BACKEND_URL }}
+            MOBILE_CALLBACK_URL=${{ secrets.MOBILE_CALLBACK_URL }}
           file: ./deployment/Dockerfile.${{ matrix.component }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
This pull request updates the way environment variables are referenced when building and pushing Docker images in the CI/CD workflow. Instead of setting environment variables explicitly, it now injects secret values directly into the Docker build arguments.

Docker build configuration:

* Updated the `build-args` for the Docker image build step in `.github/workflows/cicd.yml` to use `${{ secrets.FRONTEND_URL }}`, `${{ secrets.BACKEND_URL }}`, and `${{ secrets.MOBILE_CALLBACK_URL }}` directly, removing the intermediate environment variable assignments.