### PR TITLE
fix (ci/cd): deployment now depends on web tests instead of web linter

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -162,8 +162,8 @@ jobs:
         working-directory: ./web
         run: npm run format:check
 
-  frontend-test:
-    name: Frontend tests
+  web-test:
+    name: Web Frontend tests
     needs: web-linter
     runs-on: ubuntu-latest
     steps:
@@ -228,7 +228,7 @@ jobs:
 
   deploy-app:
     name: Deploy application
-    needs: [backend-test, web-linter, mobile-test]
+    needs: [backend-test, web-test, mobile-test]
     if: ${{ needs.check_repository.outputs.backend_changed == 'true' || needs.check_repository.outputs.web_changed == 'true' || needs.check_repository.outputs.mobile_changed == 'true' }}
     runs-on: ubuntu-latest
     environment: AREA


### PR DESCRIPTION
This pull request updates the CI/CD workflow configuration to improve clarity and maintain consistency in job naming and dependencies. The most important changes are:

**Workflow job renaming and dependency updates:**

* Renamed the `frontend-test` job to `web-test` and updated its display name to "Web Frontend tests" in `.github/workflows/cicd.yml` for better clarity and alignment with other job names.
* Updated the `deploy-app` job dependencies to require `web-test` instead of `web-linter`, ensuring that the deployment only proceeds after the new test job completes.