### PR TITLE
fix (ci/cd): removed args for dockerfile mobile

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -337,10 +337,6 @@ jobs:
         if: steps.check_dockerfile.outputs.dockerfile_exists == 'true'
         uses: docker/build-push-action@v5
         with:
-          build-args: |
-            FRONTEND_URL=${{ secrets.FRONTEND_URL }}
-            BACKEND_URL=${{ secrets.BACKEND_URL }}
-            MOBILE_CALLBACK_URL=${{ secrets.MOBILE_CALLBACK_URL }}
           file: ./deployment/Dockerfile.${{ matrix.component }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/deployment/Dockerfile.mobile
+++ b/deployment/Dockerfile.mobile
@@ -2,19 +2,6 @@
 FROM ghcr.io/cirruslabs/flutter:3.35.7 AS builder
 
 ARG SKIP_APK_BUILD=false
-ARG FRONTEND_URL
-ARG BACKEND_URL
-ARG MOBILE_CALLBACK_URL
-
-RUN if [ -z "$FRONTEND_URL" ]; \
-        then echo "FRONTEND_URL is required" && exit 1; \
-    fi && \
-    if [ -z "$BACKEND_URL" ]; \
-        then echo "BACKEND_URL is required" && exit 1; \
-    fi && \
-    if [ -z "$MOBILE_CALLBACK_URL" ]; \
-        then echo "MOBILE_CALLBACK_URL is required" && exit 1; \
-    fi
 
 WORKDIR /app
 
@@ -29,10 +16,7 @@ RUN flutter clean
 RUN flutter pub get
 
 RUN if [ "$SKIP_APK_BUILD" != "true" ]; then \
-        flutter build apk --release \
-        --dart-define=FRONTEND_URL="$FRONTEND_URL" \
-        --dart-define=BACKEND_URL="$BACKEND_URL" \
-        --dart-define=MOBILE_CALLBACK_URL="$MOBILE_CALLBACK_URL"; \
+        flutter build apk --release; \
     else \
         echo "Skipping APK build for development"; \
         mkdir -p /app/build/app/outputs/flutter-apk/; \

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -72,9 +72,6 @@ services:
       dockerfile: ${DOCKERFILE_MOBILE:-deployment/Dockerfile.mobile}
       args:
         - SKIP_APK_BUILD=${SKIP_APK_BUILD:-false}
-        - FRONTEND_URL=${FRONTEND_URL}
-        - BACKEND_URL=${BACKEND_URL}
-        - MOBILE_CALLBACK_URL=${MOBILE_CALLBACK_URL}
     container_name: area_mobile
     env_file:
       - .env


### PR DESCRIPTION
This pull request removes the use of build-time environment variables for mobile Docker builds, simplifying the build process and shifting configuration to runtime. The most important changes are grouped below:

**Docker build configuration simplification:**

* Removed `FRONTEND_URL`, `BACKEND_URL`, and `MOBILE_CALLBACK_URL` as build arguments from the mobile Docker build workflow in `.github/workflows/cicd.yml` and `deployment/docker-compose.yml`. [[1]](diffhunk://#diff-6727e33ccc9195d67f0786e1384f8f1cdaf4090c3e77547943105bd2b28c99d0L340-L343) [[2]](diffhunk://#diff-2b55e4c5b746598b1dd89b62c657486786aaf3faca0d6c95c7225f619d47e164L75-L77)
* Deleted the corresponding `ARG` declarations and required variable checks from `deployment/Dockerfile.mobile`, so these variables are no longer needed at build time.

**APK build process update:**

* Updated the APK build step in `deployment/Dockerfile.mobile` to remove the use of `--dart-define` for the eliminated environment variables, further decoupling build-time configuration from runtime.